### PR TITLE
Fix touchpad swipe/pinch and mouse wheel scroll behaviour

### DIFF
--- a/data/pref.xml
+++ b/data/pref.xml
@@ -102,7 +102,6 @@
     </section>
     <section id="editor" text="Editor">
       <option id="zoom_with_wheel" type="bool" default="true" migrate="Options.ZoomWithMouseWheel" />
-      <option id="zoom_with_slide" type="bool" default="false" />
       <option id="zoom_from_center_with_wheel" type="bool" default="false" />
       <option id="zoom_from_center_with_keys" type="bool" default="false" />
       <option id="invert_horizontal_scroll" type="bool" default="false" />

--- a/data/widgets/options.xml
+++ b/data/widgets/options.xml
@@ -75,8 +75,7 @@
         <!-- Editor -->
         <vbox id="section_editor">
           <separator text="Editor" horizontal="true" />
-          <check text="Zoom with scroll wheel" id="wheel_zoom" />
-          <check text="Zoom sliding two fingers up or down" id="slide_zoom" />
+          <check text="Zoom with scroll wheel" id="wheel_zoom" tooltip="When checked, the scroll wheel zooms the sprite&#10;and Ctrl+wheel pans it. Uncheck to swap this&#10;(wheel pans, Ctrl+wheel zooms). Two-finger&#10;trackpad swipes always pan, and pinch always&#10;zooms (Ctrl+pinch snaps to integer zoom levels)." />
           <check text="Zoom from center with scroll wheel" id="zoom_from_center_with_wheel" />
           <check text="Zoom from center with keys" id="zoom_from_center_with_keys" />
           <check text="Invert horizontal scroll" id="invert_horizontal_scroll" />

--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -197,13 +197,6 @@ public:
     // Zoom with Scroll Wheel
     wheelZoom()->setSelected(m_pref.editor.zoomWithWheel());
 
-    // Zoom sliding two fingers
-#if __APPLE__
-    slideZoom()->setSelected(m_pref.editor.zoomWithSlide());
-#else
-    slideZoom()->setVisible(false);
-#endif
-
     // Checked background size
     checkedBgSize()->addItem("16x16");
     checkedBgSize()->addItem("8x8");
@@ -287,9 +280,6 @@ public:
     m_pref.editor.invertVerticalScroll(invertVerticalScroll()->isSelected());
     m_pref.editor.showScrollbars(showScrollbars()->isSelected());
     m_pref.editor.zoomWithWheel(wheelZoom()->isSelected());
-#if __APPLE__
-    m_pref.editor.zoomWithSlide(slideZoom()->isSelected());
-#endif
     m_pref.editor.rightClickMode(static_cast<app::gen::RightClickMode>(rightClickBehavior()->getSelectedItemIndex()));
     m_pref.editor.cursorColor(m_cursorColor->getColor());
     m_pref.editor.brushPreview(static_cast<app::gen::BrushPreview>(brushPreview()->getSelectedItemIndex()));

--- a/src/app/ui/editor/state_with_wheel_behavior.cpp
+++ b/src/app/ui/editor/state_with_wheel_behavior.cpp
@@ -12,7 +12,6 @@
 #include "app/ui/editor/state_with_wheel_behavior.h"
 
 #include "app/app.h"
-#include "app/commands/commands.h"
 #include "app/modules/palettes.h"
 #include "app/pref/preferences.h"
 #include "app/ui/color_bar.h"
@@ -31,15 +30,13 @@ enum WHEEL_ACTION { WHEEL_NONE,
                     WHEEL_VSCROLL,
                     WHEEL_HSCROLL,
                     WHEEL_FG,
-                    WHEEL_BG,
-                    WHEEL_FRAME };
+                    WHEEL_BG };
 
 bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
 {
   gfx::Point delta = msg->wheelDelta();
   double dz = delta.x + delta.y;
   WHEEL_ACTION wheelAction = WHEEL_NONE;
-  bool scrollBigSteps = false;
 
   // Alt+mouse wheel changes the fg/bg colors
   if (msg->altPressed()) {
@@ -48,41 +45,32 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
     else
       wheelAction = WHEEL_FG;
   }
-  // Normal behavior: mouse wheel zooms If the message is from a
-  // precise wheel i.e. a trackpad/touch-like device, we scroll by
-  // default.
-  else if (Preferences::instance().editor.zoomWithWheel() && !msg->preciseWheel()) {
-    if (msg->ctrlPressed())
-      wheelAction = WHEEL_FRAME;
-    else if (delta.x != 0 || msg->shiftPressed())
-      wheelAction = WHEEL_HSCROLL;
-    else
-      wheelAction = WHEEL_ZOOM;
+  // A precise wheel comes from a touchpad/trackpad two-finger swipe:
+  // it always freely pans the viewport on both axes (following the
+  // physical swipe direction), it never zooms.
+  else if (msg->preciseWheel()) {
+    View* view = View::getView(editor);
+    gfx::Point scroll = view->viewScroll();
+
+    if (Preferences::instance().editor.invertHorizontalScroll())
+      delta.x = -delta.x;
+    if (Preferences::instance().editor.invertVerticalScroll())
+      delta.y = -delta.y;
+
+    editor->setEditorScroll(scroll+delta);
+    return true;
   }
-  // Zoom sliding two fingers
-  else if (Preferences::instance().editor.zoomWithSlide() && msg->preciseWheel()) {
-    if (msg->ctrlPressed())
-      wheelAction = WHEEL_FRAME;
-    else if (std::abs(delta.x) > std::abs(delta.y)) {
-      delta.y = 0;
-      dz = delta.x;
-      wheelAction = WHEEL_HSCROLL;
-    }
-    else if (msg->shiftPressed()) {
-      delta.x = 0;
-      dz = delta.y;
-      wheelAction = WHEEL_VSCROLL;
-    }
-    else {
-      delta.x = 0;
-      dz = delta.y;
-      wheelAction = WHEEL_ZOOM;
-    }
-  }
-  // For laptops, it's convenient to that Ctrl+wheel zoom (because
-  // it's the "pinch" gesture).
+  // Regular wheel notches (mouse wheel or a trackpad reporting
+  // itself as a mouse): vertical and horizontal movement get the
+  // same treatment, either both pan or both zoom. Ctrl toggles
+  // between the two modes configured by "Zoom with scroll wheel"
+  // (the same modifier used for the pinch gesture in onTouchMagnify).
   else {
+    bool zoomMode = Preferences::instance().editor.zoomWithWheel();
     if (msg->ctrlPressed())
+      zoomMode = !zoomMode;
+
+    if (zoomMode)
       wheelAction = WHEEL_ZOOM;
     else if (delta.x != 0 || msg->shiftPressed())
       wheelAction = WHEEL_HSCROLL;
@@ -114,27 +102,9 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
       }
       break;
 
-    case WHEEL_FRAME:
-      {
-        Command* command = CommandsModule::instance()->getCommandByName
-          ((dz < 0.0) ? CommandId::GotoNextFrame:
-                        CommandId::GotoPreviousFrame);
-        if (command)
-          UIContext::instance()->executeCommand(command);
-      }
-      break;
-
     case WHEEL_ZOOM: {
       render::Zoom zoom = editor->zoom();
-
-      if (msg->preciseWheel()) {
-        dz /= 1.5;
-        if (dz < -1.0) dz = -1.0;
-        else if (dz > 1.0) dz = 1.0;
-      }
-
       zoom = render::Zoom::fromLinearScale(zoom.linearScale() - int(dz));
-
       setZoom(editor, zoom, msg->position());
       break;
     }
@@ -143,23 +113,15 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
     case WHEEL_VSCROLL: {
       View* view = View::getView(editor);
       gfx::Point scroll = view->viewScroll();
+      gfx::Rect vp = view->viewportBounds();
 
-      if (!msg->preciseWheel()) {
-        gfx::Rect vp = view->viewportBounds();
-
-        if (wheelAction == WHEEL_HSCROLL) {
-          delta.x = int(dz * vp.w);
-        }
-        else {
-          delta.y = int(dz * vp.h);
-        }
-
-        if (scrollBigSteps) {
-          delta /= 2;
-        }
-        else {
-          delta /= 10;
-        }
+      if (wheelAction == WHEEL_HSCROLL) {
+        delta.x = int(dz * vp.w) / 10;
+        delta.y = 0;
+      }
+      else {
+        delta.y = int(dz * vp.h) / 10;
+        delta.x = 0;
       }
 
       if (Preferences::instance().editor.invertHorizontalScroll()) {
@@ -181,10 +143,15 @@ bool StateWithWheelBehavior::onMouseWheel(Editor* editor, MouseMessage* msg)
 bool StateWithWheelBehavior::onTouchMagnify(Editor* editor, ui::TouchMessage* msg)
 {
   render::Zoom zoom = editor->zoom();
-  zoom = render::Zoom::fromScale(
+  render::Zoom newZoom = render::Zoom::fromScale(
     zoom.internalScale() + zoom.internalScale() * msg->magnification());
 
-  setZoom(editor, zoom, msg->position());
+  // Ctrl+pinch snaps to the closest integer zoom level instead of
+  // zooming freely.
+  if (msg->ctrlPressed())
+    newZoom = render::Zoom::fromLinearScale(newZoom.linearScale());
+
+  setZoom(editor, newZoom, msg->position());
   return true;
 }
 

--- a/src/she/CMakeLists.txt
+++ b/src/she/CMakeLists.txt
@@ -41,6 +41,14 @@ if(APPLE)
     osx/logger.mm
     osx/native_dialogs.mm
     osx/tablet.mm)
+
+  # The native (non-SDL2) osx backend already handles pinch/magnify
+  # gestures directly in osx/view.mm; SDL2's Cocoa backend does not
+  # forward them at all, so it needs its own hook.
+  if(USE_SDL2_BACKEND)
+    list(APPEND SHE_SOURCES
+      osx/magnify_gesture.mm)
+  endif()
 endif()
 
 if(WITH_GTK_FILE_DIALOG_SUPPORT AND UNIX AND NOT APPLE AND NOT BEOS)

--- a/src/she/osx/magnify_gesture.mm
+++ b/src/she/osx/magnify_gesture.mm
@@ -1,0 +1,95 @@
+// SHE library
+// Copyright (C) 2021 LibreSprite contributors
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+// SDL2's Cocoa backend never forwards trackpad pinch (magnify) gestures
+// as an SDL event, so we swizzle NSView::magnifyWithEvent: on SDL's own
+// content view to queue our own TouchMagnify events instead.
+
+#import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
+
+#if __has_include(<SDL2/SDL.h>)
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_syswm.h>
+#else
+#include <SDL.h>
+#include <SDL_syswm.h>
+#endif
+
+#include "gfx/point.h"
+#include "she/event.h"
+#include "she/event_queue.h"
+#include "she/sdl2/sdl2_display.h"
+
+namespace {
+
+IMP g_originalMagnifyWithEvent = nullptr;
+
+void custom_magnifyWithEvent(id self, SEL _cmd, NSEvent* event)
+{
+  int scale = she::unique_display ? she::unique_display->scale() : 1;
+  NSView* view = (NSView*)self;
+  NSPoint point = [view convertPoint:[event locationInWindow] fromView:nil];
+
+  she::Event ev;
+  ev.setType(she::Event::TouchMagnify);
+  ev.setMagnification(event.magnification);
+  ev.setPointerType(she::PointerType::Multitouch);
+  ev.setPosition(gfx::Point(
+    point.x / scale,
+    (view.bounds.size.height - point.y) / scale));
+
+  she::queue_event(ev);
+
+  if (g_originalMagnifyWithEvent)
+    ((void (*)(id, SEL, NSEvent*))g_originalMagnifyWithEvent)(self, _cmd, event);
+}
+
+} // anonymous namespace
+
+namespace osx_magnify {
+
+bool init(SDL_Window* window)
+{
+  if (!window)
+    return false;
+
+  SDL_SysWMinfo wmInfo;
+  SDL_VERSION(&wmInfo.version);
+  if (!SDL_GetWindowWMInfo(window, &wmInfo))
+    return false;
+  if (wmInfo.subsystem != SDL_SYSWM_COCOA)
+    return false;
+
+  NSWindow* nsWindow = wmInfo.info.cocoa.window;
+  NSView* contentView = nsWindow ? [nsWindow contentView] : nil;
+  if (!contentView)
+    return false;
+
+  Class viewClass = [contentView class];
+  SEL magnifySel = @selector(magnifyWithEvent:);
+  Method existingMethod = class_getInstanceMethod(viewClass, magnifySel);
+  if (existingMethod) {
+    g_originalMagnifyWithEvent =
+      method_setImplementation(existingMethod, (IMP)custom_magnifyWithEvent);
+  }
+  else {
+    class_addMethod(viewClass, magnifySel, (IMP)custom_magnifyWithEvent, "v@:@");
+  }
+
+  if (@available(macOS 10.12.2, *)) {
+    contentView.allowedTouchTypes = NSTouchTypeMaskDirect | NSTouchTypeMaskIndirect;
+  }
+
+  return true;
+}
+
+} // namespace osx_magnify

--- a/src/she/sdl2/sdl2_display.cpp
+++ b/src/she/sdl2/sdl2_display.cpp
@@ -1,5 +1,6 @@
 // SHE library
 // Copyright (C) 2021 LibreSprite contributors
+// Besprited | Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -40,6 +41,9 @@
 #if __APPLE__
 namespace osx_tablet {
   int init();
+}
+namespace osx_magnify {
+  bool init(SDL_Window* window);
 }
 #endif
 
@@ -115,6 +119,8 @@ namespace she {
 #endif
 #elif __APPLE__
       tabletSupport = osx_tablet::init();
+      bool magnifySupport = osx_magnify::init(m_window);
+      std::cout << "Magnify gesture support: " << (magnifySupport ? "OK" : "FAILED") << std::endl;
 #endif
       std::cout << "Tablet support: " << (tabletSupport ? "OK" : "FAILED") << std::endl;
     }, true);

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -497,10 +497,29 @@ namespace she {
           penPressure = std::max<>(sdlEvent.tfinger.pressure, 0.0001f);
           continue;
 
-        case SDL_MOUSEWHEEL:
+        case SDL_MOUSEWHEEL: {
           event.setType(Event::MouseWheel);
           event.setModifiers(getSheModifiers());
           event.setWheelDelta({-sdlEvent.wheel.x, -sdlEvent.wheel.y});
+
+          bool isPrecise = false;
+#ifdef __APPLE__
+          // Virtually all scroll input on macOS comes from a trackpad,
+          // and pinch (handled separately as a TouchMagnify event) is
+          // the dedicated zoom gesture, so always treat wheel events
+          // here as a free-panning swipe.
+          isPrecise = true;
+#elif SDL_VERSION_ATLEAST(2, 0, 18)
+          // A trackpad/precision touchpad reports sub-notch deltas in
+          // preciseX/preciseY; a regular wheel notch reports the same
+          // (rounded) value in both the integer and precise fields.
+          isPrecise = (sdlEvent.wheel.preciseX != (float)sdlEvent.wheel.x) ||
+                      (sdlEvent.wheel.preciseY != (float)sdlEvent.wheel.y);
+#endif
+          event.setPreciseWheel(isPrecise);
+          if (isPrecise)
+            event.setPointerType(PointerType::Multitouch);
+
           int x, y;
           SDL_GetMouseState(&x, &y);
           event.setPosition({
@@ -508,6 +527,7 @@ namespace she {
               y / unique_display->scale()
             });
           return;
+        }
 
         case SDL_MOUSEBUTTONUP:
         case SDL_MOUSEBUTTONDOWN: {


### PR DESCRIPTION
- Two-finger trackpad swipes (precise wheel events) now always freely pan the viewport on both axes, instead of behaving like mouse wheel notches (vertical swipe zooming, horizontal swipe panning).
- Pinch gesture zoom stays free/continuous by default; holding Ctrl while pinching now snaps to the nearest integer zoom level.
- Regular mouse wheel scrolling is now consistent between the vertical and horizontal axes: both pan by default, or both zoom when Ctrl is held (or vice versa if "Zoom with scroll wheel" is unchecked), instead of vertical wheel zooming while horizontal wheel/shift+wheel panned.
- Removed the now-obsolete "Zoom sliding two fingers" preference, since swiping always pans.

Fixes #11

Co-authored-by: Claude <noreply@anthropic.com>