### PR TITLE
Add Alt+Right-click / Alt+Ctrl+Left-click drag to change brush size

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -502,6 +502,14 @@
       <!-- Modifiers for two-or-more-points tools -->
       <key action="MoveOrigin" shortcut="Space" />
 
+      <!-- Hold and drag with the right mouse button to change the
+           brush size (X axis) and, when applicable, the ink opacity
+           (Y axis) -->
+      <key action="ChangeBrushSize" shortcut="Alt" />
+
+      <!-- Alternative: hold and drag with the left mouse button -->
+      <key action="ChangeBrushSizeAlt" shortcut="Alt+Ctrl" mac="Alt+Cmd" />
+
       <!-- Without default shortcuts -->
       <key action="LeftMouseButton" />
       <key action="RightMouseButton" />

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -398,6 +398,7 @@ add_library(app-lib
   ui/document_view.cpp
   ui/drop_down_button.cpp
   ui/editor/brush_preview.cpp
+  ui/editor/change_brush_size_state.cpp
   ui/editor/drawing_state.cpp
   ui/editor/editor.cpp
   ui/editor/editor_observers.cpp

--- a/src/app/ui/editor/change_brush_size_state.cpp
+++ b/src/app/ui/editor/change_brush_size_state.cpp
@@ -1,0 +1,127 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/ui/editor/change_brush_size_state.h"
+
+#include "app/app.h"
+#include "app/pref/preferences.h"
+#include "app/tools/ink.h"
+#include "app/tools/ink_type.h"
+#include "app/tools/tool.h"
+#include "app/ui/editor/editor.h"
+#include "app/ui/status_bar.h"
+#include "doc/brush.h"
+#include "ui/message.h"
+
+#include <algorithm>
+
+namespace app {
+
+using namespace ui;
+
+ChangeBrushSizeState::ChangeBrushSizeState()
+  : m_tool(nullptr)
+  , m_startSize(doc::Brush::kMinBrushSize)
+  , m_startOpacity(0)
+  , m_changeOpacity(false)
+{
+}
+
+ChangeBrushSizeState::~ChangeBrushSizeState()
+{
+}
+
+bool ChangeBrushSizeState::onMouseDown(Editor* editor, MouseMessage* msg)
+{
+  m_startPos = msg->position();
+  m_tool = App::instance()->activeTool();
+
+  ToolPreferences& toolPref = Preferences::instance().tool(m_tool);
+  m_startSize = toolPref.brush.size();
+  m_startOpacity = toolPref.opacity();
+
+  bool isPaint = m_tool->getInk(0)->isPaint() || m_tool->getInk(1)->isPaint();
+  bool isEffect = m_tool->getInk(0)->isEffect() || m_tool->getInk(1)->isEffect();
+
+  // The Y axis changes the opacity for tools whose ink supports it
+  // (e.g. Alpha Compositing) and for effect-based tools that always
+  // have an opacity value of their own (e.g. the Eraser).
+  m_changeOpacity =
+    isEffect || (isPaint && tools::inkHasOpacity(toolPref.ink()));
+
+  editor->captureMouse();
+  return true;
+}
+
+bool ChangeBrushSizeState::onMouseUp(Editor* editor, MouseMessage* msg)
+{
+  editor->backToPreviousState();
+  editor->releaseMouse();
+  return true;
+}
+
+bool ChangeBrushSizeState::onMouseMove(Editor* editor, MouseMessage* msg)
+{
+  if (!m_tool)
+    return true;
+
+  gfx::Point delta = msg->position() - m_startPos;
+  ToolPreferences& toolPref = Preferences::instance().tool(m_tool);
+
+  int newSize = std::max(doc::Brush::kMinBrushSize,
+    std::min(doc::Brush::kMaxBrushSize, m_startSize + delta.x));
+  toolPref.brush.size(newSize);
+
+  if (m_changeOpacity) {
+    int newOpacity = std::max(0, std::min(255, m_startOpacity - delta.y));
+    toolPref.opacity(newOpacity);
+  }
+
+  editor->updateStatusBar();
+  return true;
+}
+
+bool ChangeBrushSizeState::onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos)
+{
+  editor->showMouseCursor(kSizeWECursor);
+  return true;
+}
+
+bool ChangeBrushSizeState::onKeyDown(Editor* editor, KeyMessage* msg)
+{
+  return false;
+}
+
+bool ChangeBrushSizeState::onKeyUp(Editor* editor, KeyMessage* msg)
+{
+  return false;
+}
+
+bool ChangeBrushSizeState::onUpdateStatusBar(Editor* editor)
+{
+  if (!m_tool)
+    return false;
+
+  ToolPreferences& toolPref = Preferences::instance().tool(m_tool);
+
+  if (m_changeOpacity) {
+    StatusBar::instance()->setStatusText(0,
+      "Brush Size: %d, Opacity: %d",
+      toolPref.brush.size(), toolPref.opacity());
+  }
+  else {
+    StatusBar::instance()->setStatusText(0,
+      "Brush Size: %d", toolPref.brush.size());
+  }
+
+  return true;
+}
+
+} // namespace app

--- a/src/app/ui/editor/change_brush_size_state.h
+++ b/src/app/ui/editor/change_brush_size_state.h
@@ -1,0 +1,43 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include "app/ui/editor/editor_state.h"
+#include "gfx/point.h"
+
+namespace app {
+
+  namespace tools {
+    class Tool;
+  }
+
+  // Lets the user drag the mouse (while holding the "Change Brush
+  // Size" action modifier, e.g. Alt+Right-click) to change the
+  // active tool's brush size (horizontal movement) and, when the
+  // tool's ink supports it, its opacity (vertical movement).
+  class ChangeBrushSizeState : public EditorState {
+  public:
+    ChangeBrushSizeState();
+    virtual ~ChangeBrushSizeState();
+    virtual bool isTemporalState() const override { return true; }
+    virtual bool onMouseDown(Editor* editor, ui::MouseMessage* msg) override;
+    virtual bool onMouseUp(Editor* editor, ui::MouseMessage* msg) override;
+    virtual bool onMouseMove(Editor* editor, ui::MouseMessage* msg) override;
+    virtual bool onSetCursor(Editor* editor, const gfx::Point& mouseScreenPos) override;
+    virtual bool onKeyDown(Editor* editor, ui::KeyMessage* msg) override;
+    virtual bool onKeyUp(Editor* editor, ui::KeyMessage* msg) override;
+    virtual bool onUpdateStatusBar(Editor* editor) override;
+
+  private:
+    tools::Tool* m_tool;
+    gfx::Point m_startPos;
+    int m_startSize;
+    int m_startOpacity;
+    bool m_changeOpacity;
+  };
+
+} // namespace app

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -23,6 +23,7 @@
 #include "app/tools/pick_ink.h"
 #include "app/tools/tool.h"
 #include "app/ui/document_view.h"
+#include "app/ui/editor/change_brush_size_state.h"
 #include "app/ui/editor/drawing_state.h"
 #include "app/ui/editor/editor.h"
 #include "app/ui/editor/editor_customization_delegate.h"
@@ -155,6 +156,30 @@ bool StandbyState::checkForZoom(Editor* editor, MouseMessage* msg)
     return false;
 }
 
+bool StandbyState::checkForChangeBrushSize(Editor* editor, MouseMessage* msg)
+{
+  EditorCustomizationDelegate* customization = editor->getCustomizationDelegate();
+  if (!customization)
+    return false;
+
+  KeyAction action = customization->getPressedKeyAction(KeyContext::Any);
+
+  bool primary = (msg->right() &&
+                  (int(action & KeyAction::ChangeBrushSize) != 0));
+  bool alternative = (msg->left() &&
+                       (int(action & KeyAction::ChangeBrushSizeAlt) != 0));
+
+  if (primary || alternative) {
+    EditorStatePtr newState(new ChangeBrushSizeState());
+    editor->setState(newState);
+
+    newState->onMouseDown(editor, msg);
+    return true;
+  }
+
+  return false;
+}
+
 bool StandbyState::onMouseDown(Editor* editor, MouseMessage* msg)
 {
   if (editor->hasCapture())
@@ -169,6 +194,10 @@ bool StandbyState::onMouseDown(Editor* editor, MouseMessage* msg)
 
   // When an editor is clicked the current view is changed.
   context->setActiveView(editor->getDocumentView());
+
+  // Start brush size/opacity drag loop
+  if (checkForChangeBrushSize(editor, msg))
+    return true;
 
   // Start scroll loop
   if (checkForScroll(editor, msg) || checkForZoom(editor, msg))

--- a/src/app/ui/editor/standby_state.h
+++ b/src/app/ui/editor/standby_state.h
@@ -49,6 +49,7 @@ namespace app {
     // user wants to scroll".
     bool checkForScroll(Editor* editor, ui::MouseMessage* msg);
     bool checkForZoom(Editor* editor, ui::MouseMessage* msg);
+    bool checkForChangeBrushSize(Editor* editor, ui::MouseMessage* msg);
     void callEyedropper(Editor* editor);
 
     class Decorator : public EditorDecorator {

--- a/src/app/ui/keyboard_shortcuts.cpp
+++ b/src/app/ui/keyboard_shortcuts.cpp
@@ -50,6 +50,8 @@ namespace {
     { "DrawFromCenter"      , "Draw From Center"   , app::KeyAction::DrawFromCenter },
     { "LeftMouseButton"     , "Trigger Left Mouse Button" , app::KeyAction::LeftMouseButton },
     { "RightMouseButton"    , "Trigger Right Mouse Button" , app::KeyAction::RightMouseButton },
+    { "ChangeBrushSize"     , "Change Brush Size (Right-click Drag)" , app::KeyAction::ChangeBrushSize },
+    { "ChangeBrushSizeAlt"  , "Change Brush Size (Left-click Drag, Alternative)" , app::KeyAction::ChangeBrushSizeAlt },
     { NULL                  , NULL                 , app::KeyAction::None }
   };
 
@@ -170,6 +172,12 @@ Key::Key(KeyAction action)
       m_keycontext = KeyContext::Any;
       break;
     case KeyAction::RightMouseButton:
+      m_keycontext = KeyContext::Any;
+      break;
+    case KeyAction::ChangeBrushSize:
+      m_keycontext = KeyContext::Any;
+      break;
+    case KeyAction::ChangeBrushSizeAlt:
       m_keycontext = KeyContext::Any;
       break;
   }

--- a/src/app/ui/keyboard_shortcuts.h
+++ b/src/app/ui/keyboard_shortcuts.h
@@ -70,6 +70,8 @@ namespace app {
     SquareAspect              = 0x00001000,
     DrawFromCenter            = 0x00002000,
     ScaleFromCenter           = 0x00004000,
+    ChangeBrushSize           = 0x00008000,
+    ChangeBrushSizeAlt        = 0x00010000,
   };
 
   inline KeyAction operator&(KeyAction a, KeyAction b) {


### PR DESCRIPTION
Photoshop-style drag gesture to quickly change the active tool's brush size (and, where applicable, opacity/alpha):

- `Alt` + Right-click drag
- `Alt`+`Ctrl` (`Cmd` on macOS) + Left-click drag (alternative)

Dragging horizontally changes brush size (min 1); dragging vertically changes opacity/alpha (0-255) when the tool's ink is Alpha Compositing/Lock Alpha, or for effect tools like the Eraser. Both shortcuts are implemented as customizable Action Modifiers, editable from Edit > Keyboard Shortcuts.

Fixes #7 