### PR TITLE
Preserve blend modes when flattening/merging layers in indexed color mode

### DIFF
--- a/src/app/cmd/flatten_layers.cpp
+++ b/src/app/cmd/flatten_layers.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite  | Copyright (C) 2001-2015 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -20,6 +20,7 @@
 #include "app/cmd/set_layer_flags.h"
 #include "app/cmd/unlink_cel.h"
 #include "app/document.h"
+#include "doc/blend_mode.h"
 #include "doc/cel.h"
 #include "doc/layer.h"
 #include "doc/primitives.h"
@@ -39,18 +40,23 @@ void FlattenLayers::onExecute()
   Sprite* sprite = this->sprite();
   app::Document* doc = static_cast<app::Document*>(sprite->document());
 
-  // Create a temporary image.
+  // Create a temporary image. Its mask color must match the sprite's
+  // transparent color, as the image is composited onto the background
+  // color below (indexed images use it to know which pixels are empty).
   ImageRef image(Image::create(sprite->pixelFormat(),
       sprite->width(),
       sprite->height()));
+  image->setMaskColor(sprite->transparentColor());
 
   LayerImage* flatLayer;  // The layer onto which everything will be flattened.
   color_t     bgcolor;    // The background color to use for flatLayer.
+  bool        ontoBackground;
 
   flatLayer = sprite->backgroundLayer();
   if (flatLayer && flatLayer->isVisible()) {
     // There exists a visible background layer, so we will flatten onto that.
     bgcolor = doc->bgColor(flatLayer);
+    ontoBackground = true;
   }
   else {
     // Create a new transparent layer to flatten everything onto.
@@ -59,16 +65,41 @@ void FlattenLayers::onExecute()
     executeAndAdd(new cmd::AddLayer(sprite->folder(), flatLayer, nullptr));
     executeAndAdd(new cmd::SetLayerName(flatLayer, "Flattened"));
     bgcolor = sprite->transparentColor();
+    ontoBackground = false;
   }
+
+  // Buffer to composite the background color underneath the rendered
+  // frame (see below). It's only needed when flattening onto a
+  // background layer, as bgcolor is the transparent color otherwise.
+  ImageRef bgImage;
+  if (ontoBackground)
+    bgImage.reset(Image::create(sprite->pixelFormat(),
+        sprite->width(),
+        sprite->height()));
 
   render::Render render;
   render.setBgType(render::BgType::NONE);
 
   // Copy all frames to the background.
   for (frame_t frame(0); frame<sprite->totalFrames(); ++frame) {
-    // Clear the image and render this frame.
-    clear_image(image.get(), bgcolor);
+    // Render this frame onto an empty backdrop. Pre-filling the buffer
+    // with the background color would hide the sprite's real per-pixel
+    // alpha from the layers' blend functions, which fall back to Normal
+    // blending only where the backdrop is empty (see doc/blend_funcs.cpp),
+    // so every special-blend layer would end up blended against the
+    // background color instead of against "no content".
+    clear_image(image.get(), sprite->transparentColor());
     render.renderSprite(image.get(), sprite, frame);
+
+    // Now that the frame is composited with its own alpha, drop the
+    // background color in behind it.
+    Image* flatImage = image.get();
+    if (bgImage) {
+      clear_image(bgImage.get(), bgcolor);
+      render::composite_image(bgImage.get(), image.get(),
+          sprite->palette(frame), 0, 0, 255, BlendMode::NORMAL);
+      flatImage = bgImage.get();
+    }
 
     // TODO Keep cel links when possible
 
@@ -81,11 +112,11 @@ void FlattenLayers::onExecute()
       cel_image = cel->imageRef();
       ASSERT(cel_image);
 
-      executeAndAdd(new cmd::CopyRect(cel_image.get(), image.get(),
-          gfx::Clip(0, 0, image->bounds())));
+      executeAndAdd(new cmd::CopyRect(cel_image.get(), flatImage,
+          gfx::Clip(0, 0, flatImage->bounds())));
     }
     else {
-      cel_image.reset(Image::createCopy(image.get()));
+      cel_image.reset(Image::createCopy(flatImage));
       cel = std::make_shared<Cel>(frame, cel_image);
       flatLayer->addCel(cel);
     }

--- a/src/app/commands/cmd_merge_down_layer.cpp
+++ b/src/app/commands/cmd_merge_down_layer.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite  | Copyright (C) 2001-2015 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -13,6 +13,8 @@
 #include "app/cmd/add_cel.h"
 #include "app/cmd/replace_image.h"
 #include "app/cmd/set_cel_position.h"
+#include "app/cmd/set_layer_blend_mode.h"
+#include "app/cmd/set_layer_opacity.h"
 #include "app/cmd/unlink_cel.h"
 #include "app/commands/command.h"
 #include "app/context_access.h"
@@ -75,6 +77,27 @@ void MergeDownLayerCommand::onExecute(Context* context)
   LayerImage* src_layer = static_cast<LayerImage*>(writer.layer());
   Layer* dst_layer = src_layer->getPrevious();
 
+  // Merging onto a layer that has no content of its own is just moving
+  // the source layer one step down: its cels are copied verbatim below,
+  // which is the right result for the pixels (blending against an empty
+  // backdrop falls back to Normal blending, see doc/blend_funcs.cpp) but
+  // it would silently drop the source blending, so whatever is *under*
+  // the destination layer would stop blending the way it did before the
+  // merge. Let the destination layer take that blending over instead.
+  LayerImage* dst_image_layer =
+    (dst_layer->isImage() ? static_cast<LayerImage*>(dst_layer): nullptr);
+  const bool inherit_src_blending =
+    (dst_image_layer &&
+     dst_image_layer->isTransparent() &&
+     dst_image_layer->getCelsCount() == 0);
+
+  if (inherit_src_blending) {
+    transaction.execute(new cmd::SetLayerBlendMode(dst_image_layer,
+        src_layer->blendMode()));
+    transaction.execute(new cmd::SetLayerOpacity(dst_image_layer,
+        src_layer->opacity()));
+  }
+
   for (frame_t frpos = 0; frpos<sprite->totalFrames(); ++frpos) {
     // Get frames
     auto src_cel = src_layer->cel(frpos);
@@ -94,8 +117,12 @@ void MergeDownLayerCommand::onExecute(Context* context)
     // With source image?
     if (src_image) {
       int t;
-      int opacity;
-      opacity = MUL_UN8(src_cel->opacity(), src_layer->opacity(), t);
+      // The source layer opacity is already carried by the destination
+      // layer when it inherits the source blending, so baking it into
+      // the cel too would apply it twice.
+      int opacity = (inherit_src_blending ?
+                     src_cel->opacity():
+                     MUL_UN8(src_cel->opacity(), src_layer->opacity(), t));
 
       // No destination image
       if (!dst_image) {  // Only a transparent layer can have a null cel

--- a/src/render/render.cpp
+++ b/src/render/render.cpp
@@ -109,12 +109,16 @@ public:
 
 template<>
 class BlenderHelper<IndexedTraits, IndexedTraits> {
+  const Palette* m_pal;
   BlendMode m_blendMode;
+  BlendFunc m_blendFunc;
   color_t m_mask_color;
 public:
   BlenderHelper(const Image* src, const Palette* pal, BlendMode blendMode)
   {
+    m_pal = pal;
     m_blendMode = blendMode;
+    m_blendFunc = RgbTraits::get_blender(blendMode);
     m_mask_color = src->maskColor();
   }
   inline IndexedTraits::pixel_t
@@ -122,15 +126,34 @@ public:
              const IndexedTraits::pixel_t& src,
              int opacity)
   {
-    if (m_blendMode == BlendMode::SRC) {
+    if (m_blendMode == BlendMode::SRC)
       return src;
-    }
-    else {
-      if (src != m_mask_color)
-        return src;
-      else
-        return dst;
-    }
+
+    if (src == m_mask_color)
+      return dst;
+
+    // Normal blending of an indexed image is a plain copy: its pixels are
+    // either fully opaque or the transparent index, so there is nothing to
+    // interpolate and the source index survives untouched.
+    if (m_blendMode == BlendMode::NORMAL || !m_pal || !m_blendFunc)
+      return src;
+
+    // Every other blend mode has to be computed in RGB through the palette
+    // and mapped back to the closest entry. Returning the source index as
+    // Normal blending does would silently drop the layer's blend mode
+    // whenever the destination is an indexed image too, which is exactly
+    // what happens when an indexed sprite is flattened or merged down.
+    const color_t backdrop = (dst == m_mask_color ? rgba(0, 0, 0, 0):
+                                                    m_pal->getEntry(dst));
+    const color_t blended = (*m_blendFunc)(backdrop, m_pal->getEntry(src), opacity);
+    if (rgba_geta(blended) == 0)
+      return m_mask_color;
+
+    return m_pal->findBestfit(rgba_getr(blended),
+                              rgba_getg(blended),
+                              rgba_getb(blended),
+                              rgba_geta(blended),
+                              m_mask_color);
   }
 };
 

--- a/test/render/render_tests.cpp
+++ b/test/render/render_tests.cpp
@@ -13,6 +13,7 @@
 
 #include "render/render.h"
 
+#include "doc/blend_mode.h"
 #include "doc/cel.h"
 #include "doc/context.h"
 #include "doc/document.h"
@@ -20,6 +21,9 @@
 #include "doc/layer.h"
 #include "doc/palette.h"
 #include "doc/primitives.h"
+#include "doc/sprite.h"
+
+#include <memory>
 
 using namespace doc;
 using namespace render;
@@ -129,6 +133,60 @@ TEST(Render, DefaultBackgroundModeWithNonzeroTransparentIndex)
   color_t c1 = doc->sprite()->palette(0)->entry(1);
   EXPECT_NE(0, c1);
   EXPECT_2X2_PIXELS(dst.get(), 0, 0, 0, c1); // RGB transparent
+}
+
+// An indexed sprite composited onto another indexed image (as done when
+// flattening or merging down) used to drop the layer's blend mode
+// altogether and just copy the source indexes over the destination.
+TEST(Render, IndexedBlendModes)
+{
+  Context ctx;
+  Document* doc = ctx.documents().add(2, 1, ColorMode::INDEXED);
+  Sprite* sprite = doc->sprite();
+
+  // Keep the palette tiny so the best-fit search has no other candidate:
+  // index 0 is the transparent color, and multiply(200, 128) is exactly
+  // the color of index 3.
+  Palette* pal = sprite->palette(frame_t(0));
+  pal->resize(4);
+  pal->setEntry(1, rgba(200, 200, 200, 255));
+  pal->setEntry(2, rgba(128, 128, 128, 255));
+  pal->setEntry(3, rgba(100, 100, 100, 255));
+
+  // Bottom layer: content on the left pixel, nothing on the right one.
+  Image* bottom = sprite->layer(0)->cel(frame_t(0))->image();
+  clear_image(bottom, sprite->transparentColor());
+  put_pixel(bottom, 0, 0, 1);
+
+  // Top layer: covers both pixels.
+  LayerImage* top = new LayerImage(sprite);
+  sprite->folder()->addLayer(top);
+  ImageRef topImage(Image::create(IMAGE_INDEXED, 2, 1));
+  topImage->setMaskColor(sprite->transparentColor());
+  clear_image(topImage.get(), 2);
+  top->addCel(std::make_shared<Cel>(frame_t(0), topImage));
+
+  std::unique_ptr<Image> dst(Image::create(IMAGE_INDEXED, 2, 1));
+  dst->setMaskColor(sprite->transparentColor());
+
+  Render render;
+  render.setBgType(BgType::NONE);
+
+  // Normal blending is still a plain copy of the source indexes.
+  top->setBlendMode(BlendMode::NORMAL);
+  clear_image(dst.get(), sprite->transparentColor());
+  render.renderSprite(dst.get(), sprite, frame_t(0));
+  EXPECT_EQ(2, get_pixel(dst.get(), 0, 0));
+  EXPECT_EQ(2, get_pixel(dst.get(), 1, 0));
+
+  // Multiply must be computed through the palette and mapped back to the
+  // closest entry where there is a backdrop, and fall back to Normal
+  // blending where there is none.
+  top->setBlendMode(BlendMode::MULTIPLY);
+  clear_image(dst.get(), sprite->transparentColor());
+  render.renderSprite(dst.get(), sprite, frame_t(0));
+  EXPECT_EQ(3, get_pixel(dst.get(), 0, 0));
+  EXPECT_EQ(2, get_pixel(dst.get(), 1, 0));
 }
 
 TEST(Render, CheckedBackground)


### PR DESCRIPTION
Fixes #156.

Flatten and Merge Down lost special blend modes for anything other than a
fully-opaque backdrop. Three independent gaps, fixed as three commits:

1. **`FlattenLayers`** pre-filled the working buffer with the background
   color before rendering, so flattening onto a visible background layer
   made every pixel look like real content to the blend functions —
   defeating the transparent-backdrop fallback from #148/#154. Now it
   renders onto an empty backdrop and composites the background color in
   underneath afterwards, matching how `render.cpp` already handles the
   checked background.

2. **`MergeDownLayerCommand`**, when the destination has no cel at all,
   copied the source cel verbatim and silently dropped the source layer's
   blend mode and opacity. Since that case is really "move the source
   layer one step down," the destination now takes over the source's
   blend mode and opacity so layers beneath it keep blending the way they
   did before the merge.

3. **The real bug**: `BlenderHelper<IndexedTraits, IndexedTraits>` in
   `render.cpp` ignored blend mode entirely and just copied source
   indexes over the destination. The editor/export preview never showed
   this because it composites indexed sprites into an RGB surface (a
   different, blend-aware specialization); Flatten and Merge Down
   composite indexed onto indexed, so on indexed sprites every special
   blend mode was lost outright — the reported "top layer becomes
   Normal-blend and obscures everything beneath it." Fixed by blending in
   RGB through the palette and mapping the result back to the closest
   existing entry via `Palette::findBestfit`. Normal/SRC keep the plain
   index-copy fast path. The palette itself is never modified, so results
   are only as close as the existing palette allows (documented in the
   test).

Added a regression test in `render_tests.cpp` covering Normal vs.
Multiply blending between two indexed images, including the
falls-back-to-Normal-over-a-transparent-backdrop case. I could not run
the test suite in this environment — `third_party/gtest` isn't present in
this checkout — so I verified all assertions by hand-driving the same
call sequence against the built `doc`/`render` libraries.

Manually retested in the app in both indexed and RGB color modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
