### PR TITLE
Add .tar.gz package + install script for Linux releases

### DIFF
--- a/.github/workflows/cmakeLinux.yml
+++ b/.github/workflows/cmakeLinux.yml
@@ -43,14 +43,33 @@ jobs:
       run: |
         mkdir build
         if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON -DWITH_DESKTOP_INTEGRATION=ON
         else
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_DESKTOP_INTEGRATION=ON
         fi
     - name: Build the binaries
       run: |
         ninja -C build besprited
         rm build/bin/gen
+    - name: Package the tarball
+      run: |
+        export ARCH="$(uname -m)"
+        if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
+          VERSION="${{ steps.check_tag.outputs.tag }}"
+        else
+          VERSION="${{ steps.commit.outputs.short_hash }}"
+        fi
+        sh packaging/package_linux_tarball.sh "$VERSION"
+        mv build/besprited-$VERSION-linux-$ARCH.tar.gz .
+        echo "tarball=besprited-$VERSION-linux-$ARCH.tar.gz" >> $GITHUB_OUTPUT
+      id: tarball
+    - name: Upload tarball artifact
+      if: runner.arch == 'X64'
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.check_tag.outputs.has_tag == 'true' && format('besprited-{0}-linux-x86_64-tarball', steps.check_tag.outputs.tag) || 'besprited-linux-x86_64-tarball' }}
+        path: ${{ steps.tarball.outputs.tarball }}
+        if-no-files-found: error
     - name: Package the AppImage
       run: |
         export ARCH="$(uname -m)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ if(APPLE)
 endif(APPLE)
 
 if(WITH_DESKTOP_INTEGRATION)
-  add_subdirectory(desktop)
+  add_subdirectory(packaging/desktop)
 endif()
 
 ######################################################################

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,24 @@
 ## Platforms
 
 You can download installers from the [releases page](https://github.com/Veritaware/Besprited/releases).
-On linux platform, you will need to install `libfuse2` in order to run the AppImage.
+
+On Linux you have two prebuilt options:
+
+* **AppImage** – a single self-contained executable. You need `libfuse2` installed to run it.
+* **`.tar.gz` package** – a portable FHS tree (`besprited-<version>-linux-<arch>.tar.gz`) with a
+  bundled installer. Extract it and run the install script from the extracted directory:
+
+      tar -xf besprited-*-linux-*.tar.gz
+      cd besprited-*-linux-*/          # or wherever you extracted it
+
+      sudo ./install.sh                # system-wide, into /usr/local
+      ./install.sh --user              # per-user, into ~/.local (no sudo)
+
+  Use `./uninstall.sh` (with the same `--user` / `--prefix` flag you installed with) to remove it.
+  The installer does not pull in system libraries – if it reports missing `.so` files after
+  installing, install the matching packages from the [Linux dependencies](#linux-dependencies)
+  section below.
+
 If you want to compile Besprited from source, continue reading.
 
 You *should* be able to build the project on any relatively modern Linux, macOS or Windows machine.

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Besprited | Copyright (C) 2026 Veritaware
+# Licensed under the MIT License (https://opensource.org/licenses/MIT).
+#
+# Installs the bundled "usr/" tree into standard FHS locations.
+#
+#   ./install.sh                 install into /usr/local (needs root)
+#   ./install.sh --user          install into $HOME/.local (no root needed)
+#   ./install.sh --prefix DIR    install into DIR
+#
+# Run this from the root of the extracted tarball.
+
+set -e
+
+prefix=/usr/local
+user_install=0
+
+usage() {
+  cat <<EOF
+Usage: ./install.sh [options]
+
+  --user          Install into \$HOME/.local (no root required)
+  --prefix DIR    Install into DIR (default: /usr/local)
+  -h, --help      Show this help
+EOF
+}
+
+explicit_prefix=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user) user_install=1; prefix="$HOME/.local" ;;
+    --prefix) shift; [ $# -gt 0 ] || { echo "install.sh: --prefix needs an argument" >&2; exit 1; }; prefix="$1"; explicit_prefix=1 ;;
+    --prefix=*) prefix="${1#*=}"; explicit_prefix=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "install.sh: unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+srcdir=$(cd "$(dirname "$0")" && pwd)
+
+if [ ! -d "$srcdir/usr" ]; then
+  echo "install.sh: '$srcdir/usr' not found - run this script from the extracted tarball root" >&2
+  exit 1
+fi
+
+# Find the nearest existing ancestor of the prefix and check we can write to it.
+probe="$prefix"
+while [ ! -d "$probe" ]; do
+  parent=$(dirname "$probe")
+  [ "$parent" = "$probe" ] && break
+  probe="$parent"
+done
+if [ ! -w "$probe" ]; then
+  if [ "$explicit_prefix" -eq 1 ]; then
+    echo "install.sh: $probe is not writable - re-run with sudo" >&2
+  else
+    echo "install.sh: writing to $prefix requires root - re-run with sudo, or pass --user" >&2
+  fi
+  exit 1
+fi
+
+echo "Installing Besprited into $prefix ..."
+mkdir -p "$prefix"
+cp -a "$srcdir/usr/." "$prefix/"
+
+# Refresh the desktop/icon/mime caches so the launcher entry shows up right away.
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database "$prefix/share/applications" >/dev/null 2>&1 || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -f -t "$prefix/share/icons/hicolor" >/dev/null 2>&1 || true
+fi
+if command -v update-mime-database >/dev/null 2>&1 && [ -d "$prefix/share/mime" ]; then
+  update-mime-database "$prefix/share/mime" >/dev/null 2>&1 || true
+fi
+
+# Don't try to auto-resolve system dependencies (too fragile across distros);
+# just report any shared libraries the dynamic loader can't find.
+bin="$prefix/bin/besprited"
+if command -v ldd >/dev/null 2>&1 && [ -x "$bin" ]; then
+  missing=$(ldd "$bin" 2>/dev/null | awk '/not found/ { print $1 }' || true)
+  if [ -n "$missing" ]; then
+    echo
+    echo "Warning: these shared libraries could not be resolved:"
+    echo "$missing" | sed 's/^/  /'
+    echo "Install the matching packages for your distribution - see the"
+    echo "'Linux dependencies' section of INSTALL.md:"
+    echo "  https://github.com/Veritaware/Besprited/blob/trunk/INSTALL.md"
+  fi
+fi
+
+echo
+echo "Done."
+if [ "$user_install" -eq 1 ]; then
+  case ":$PATH:" in
+    *":$prefix/bin:"*) ;;
+    *) echo "Note: $prefix/bin is not on your PATH." ;;
+  esac
+fi
+echo "You may need to log out and back in for the launcher entry to appear."

--- a/packaging/package_linux_tarball.sh
+++ b/packaging/package_linux_tarball.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Besprited | Copyright (C) 2026 Veritaware
+# Licensed under the MIT License (https://opensource.org/licenses/MIT).
+#
+# Builds a portable .tar.gz package for Linux from an already-configured and
+# already-built CMake tree in ./build. The archive contains a standard FHS
+# "usr/" tree (bin/, share/besprited/data, share/applications, share/icons, ...)
+# plus install.sh / uninstall.sh at its root.
+#
+# Usage:
+#   sh packaging/package_linux_tarball.sh [VERSION]
+#
+# VERSION defaults to `git describe` (falls back to "dev"). The resulting file
+# is written to build/besprited-<version>-linux-<arch>.tar.gz.
+
+set -e
+
+rootdir=$(pwd)
+builddir="$rootdir/build"
+arch="$(uname -m)"
+version="${1:-$(git -C "$rootdir" describe --tags --always 2>/dev/null || echo dev)}"
+
+if [ ! -d "$builddir" ]; then
+  echo "package_linux_tarball.sh: '$builddir' not found - configure and build first" >&2
+  exit 1
+fi
+
+stagedir="$builddir/tarball-stage"
+rm -rf "$stagedir"
+mkdir -p "$stagedir"
+
+# Reuse the existing install() rules (src/CMakeLists.txt and
+# packaging/desktop/CMakeLists.txt) to stage the FHS tree under stage/usr.
+cmake --install "$builddir" --prefix "$stagedir/usr"
+
+# Bundle the self-install scripts at the archive root.
+cp "$rootdir/packaging/install.sh" "$stagedir/install.sh"
+cp "$rootdir/packaging/uninstall.sh" "$stagedir/uninstall.sh"
+chmod +x "$stagedir/install.sh" "$stagedir/uninstall.sh"
+
+tarball="besprited-$version-linux-$arch.tar.gz"
+rm -f "$builddir/$tarball"
+tar -czf "$builddir/$tarball" -C "$stagedir" .
+
+echo "Created $builddir/$tarball"

--- a/packaging/uninstall.sh
+++ b/packaging/uninstall.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Besprited | Copyright (C) 2026 Veritaware
+# Licensed under the MIT License (https://opensource.org/licenses/MIT).
+#
+# Removes a Besprited install that was created by install.sh. It deletes the
+# files listed in the bundled "usr/" tree from the given prefix, so run it from
+# the root of the same tarball you installed from.
+#
+#   ./uninstall.sh                 remove from /usr/local (needs root)
+#   ./uninstall.sh --user          remove from $HOME/.local
+#   ./uninstall.sh --prefix DIR    remove from DIR
+
+set -e
+
+prefix=/usr/local
+user_install=0
+
+usage() {
+  cat <<EOF
+Usage: ./uninstall.sh [options]
+
+  --user          Remove from \$HOME/.local
+  --prefix DIR    Remove from DIR (default: /usr/local)
+  -h, --help      Show this help
+EOF
+}
+
+explicit_prefix=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user) user_install=1; prefix="$HOME/.local" ;;
+    --prefix) shift; [ $# -gt 0 ] || { echo "uninstall.sh: --prefix needs an argument" >&2; exit 1; }; prefix="$1"; explicit_prefix=1 ;;
+    --prefix=*) prefix="${1#*=}"; explicit_prefix=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "uninstall.sh: unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+srcdir=$(cd "$(dirname "$0")" && pwd)
+
+if [ ! -d "$srcdir/usr" ]; then
+  echo "uninstall.sh: '$srcdir/usr' not found - run this script from the extracted tarball root" >&2
+  exit 1
+fi
+
+if [ -d "$prefix" ] && [ ! -w "$prefix" ]; then
+  if [ "$explicit_prefix" -eq 1 ]; then
+    echo "uninstall.sh: $prefix is not writable - re-run with sudo" >&2
+  else
+    echo "uninstall.sh: writing to $prefix requires root - re-run with sudo, or pass --user" >&2
+  fi
+  exit 1
+fi
+
+echo "Removing Besprited from $prefix ..."
+
+# Delete every file/symlink that the bundled tree would have installed.
+( cd "$srcdir/usr" && find . \( -type f -o -type l \) -print ) | while IFS= read -r rel; do
+  rm -f "$prefix/${rel#./}"
+done
+
+# Prune directories that are now empty (deepest first).
+( cd "$srcdir/usr" && find . -depth -type d -print ) | while IFS= read -r rel; do
+  rmdir "$prefix/${rel#./}" 2>/dev/null || true
+done
+
+if command -v update-desktop-database >/dev/null 2>&1 && [ -d "$prefix/share/applications" ]; then
+  update-desktop-database "$prefix/share/applications" >/dev/null 2>&1 || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1 && [ -d "$prefix/share/icons/hicolor" ]; then
+  gtk-update-icon-cache -f -t "$prefix/share/icons/hicolor" >/dev/null 2>&1 || true
+fi
+if command -v update-mime-database >/dev/null 2>&1 && [ -d "$prefix/share/mime" ]; then
+  update-mime-database "$prefix/share/mime" >/dev/null 2>&1 || true
+fi
+
+echo "Done."

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -11,6 +11,10 @@ endif(MSVC)
 add_subdirectory(simpleini)
 add_subdirectory(modp_b64)
 add_subdirectory(evalmath)
+
+# We only consume QuickJS as a static library (linked into besprited); its CLI
+# tools and headers must not land in our install tree / .tar.gz package.
+set(QJS_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 add_subdirectory(quickjs)
 
 # Disable observable tests


### PR DESCRIPTION
Implements #160 — a portable `.tar.gz` alternative to the AppImage for Linux releases.

## What's included

- **`packaging/package_linux_tarball.sh`** — stages an already-configured `build/` tree with `cmake --install ... --prefix stage/usr` (reusing the existing `install()` rules), bundles the installer scripts at the archive root, and produces `besprited-<version>-linux-<arch>.tar.gz`.
- **`packaging/install.sh`** (bundled at the tarball root) — copies the `usr/` tree to `/usr/local` by default, `$HOME/.local` with `--user` (no sudo), or `--prefix DIR`. Refreshes `update-desktop-database` / `gtk-update-icon-cache` / `update-mime-database` when present, then `ldd`-checks the installed binary and prints any missing `.so` names with a pointer to INSTALL.md. Does not try to auto-resolve system dependencies.
- **`packaging/uninstall.sh`** — removes exactly the files the bundled tree would have installed and prunes emptied directories.
- **`.github/workflows/cmakeLinux.yml`** — configures with `-DWITH_DESKTOP_INTEGRATION=ON` and builds/uploads the tarball alongside the AppImage on the existing tag-triggered path.
- **`INSTALL.md`** — documents the new install method.

## Incidental fixes (needed to make the above work)

- `WITH_DESKTOP_INTEGRATION` referenced a non-existent `desktop/` directory; corrected to `packaging/desktop`. The option was previously broken whenever enabled.
- QuickJS-ng was installing its CLI (`qjs`, `qjsc`) and headers into the install prefix; `QJS_ENABLE_INSTALL=OFF` keeps the package to just the editor + data + desktop files.

## Testing

- Built locally with `-DWITH_DESKTOP_INTEGRATION=ON`, produced the tarball, extracted it, and ran `install.sh` / `uninstall.sh` against both a `--prefix` sandbox and a fake `--user` `HOME`. Installed binary runs (`--version`, palette loading resolves data via `$BINDIR/../share/besprited/data`), `ldd` reports no missing libs, uninstall removes all packaged files.
- Manual test on clean Ubuntu/Fedora desktop sessions (launcher entry visibility) still recommended per the ticket — can't be verified in headless CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
