### PR TITLE
Add .deb and .rpm package generation via CPack

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -10,5 +10,5 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install -y g++ libcurl4-gnutls-dev libfreetype6-dev libgif-dev libgtest-dev libjpeg-dev libpixman-1-dev libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libwebp-dev libx11-dev libxcursor-dev ninja-build libnode-dev zlib1g-dev libarchive-dev libfuse2
+        sudo apt install -y g++ libcurl4-gnutls-dev libfreetype6-dev libgif-dev libgtest-dev libjpeg-dev libpixman-1-dev libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libwebp-dev libx11-dev libxcursor-dev ninja-build libnode-dev zlib1g-dev libarchive-dev libfuse2 dpkg-dev
         pip install cmake

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -10,5 +10,5 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install -y g++ libcurl4-gnutls-dev libfreetype6-dev libgif-dev libgtest-dev libjpeg-dev libpixman-1-dev libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libwebp-dev libx11-dev libxcursor-dev ninja-build libnode-dev zlib1g-dev libarchive-dev libfuse2 dpkg-dev
+        sudo apt install -y g++ libcurl4-gnutls-dev libfreetype6-dev libgif-dev libgtest-dev libjpeg-dev libpixman-1-dev libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libwebp-dev libx11-dev libxcursor-dev ninja-build libnode-dev zlib1g-dev libarchive-dev libfuse2
         pip install cmake

--- a/.github/workflows/cmakeLinux.yml
+++ b/.github/workflows/cmakeLinux.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         mkdir build
         if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON -DWITH_DESKTOP_INTEGRATION=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON
         else
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_DESKTOP_INTEGRATION=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON
         fi
     - name: Build the binaries
       run: |
@@ -70,6 +70,26 @@ jobs:
         name: ${{ steps.check_tag.outputs.has_tag == 'true' && format('besprited-{0}-linux-x86_64-tarball', steps.check_tag.outputs.tag) || 'besprited-linux-x86_64-tarball' }}
         path: ${{ steps.tarball.outputs.tarball }}
         if-no-files-found: error
+    - name: Package the .deb
+      id: deb
+      run: |
+        VERSION="${{ steps.check_tag.outputs.tag }}"
+        VERSION="${VERSION#v}"
+        [ -n "$VERSION" ] || VERSION="0.0.0"
+        cmake -S . -B build -DBESPRITED_PACKAGE_VERSION="$VERSION"
+        cpack -G DEB --config build/CPackConfig.cmake -B build
+        DEB=$(ls build/*.deb | head -n1)
+        dpkg --info "$DEB"
+        dpkg -c "$DEB"
+        mv "$DEB" .
+        echo "deb=$(basename "$DEB")" >> $GITHUB_OUTPUT
+    - name: Upload .deb artifact
+      if: runner.arch == 'X64' && steps.check_tag.outputs.has_tag == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: besprited-${{ steps.check_tag.outputs.tag }}-linux-amd64-deb
+        path: ${{ steps.deb.outputs.deb }}
+        if-no-files-found: error
     - name: Package the AppImage
       run: |
         export ARCH="$(uname -m)"
@@ -81,4 +101,54 @@ jobs:
       with:
         name: ${{ steps.check_tag.outputs.has_tag == 'true' && format('besprited-{0}-linux-x86_64', steps.check_tag.outputs.tag) || 'besprited-linux-x86_64' }}
         path: Besprited-anylinux-x86_64.AppImage
+        if-no-files-found: error
+
+  # Build the .rpm inside an actual Fedora environment so the auto-detected
+  # Requires: and library layout match what a Fedora user would get.
+  package-rpm:
+    name: Package .rpm (Fedora)
+    runs-on: ubuntu-26.04
+    container: fedora:latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, 'NO_SW_CHANGE') }}
+    steps:
+    - name: Install build dependencies
+      run: |
+        dnf install -y gcc-c++ cmake git ninja-build rpm-build \
+          libcurl-devel freetype-devel giflib-devel libjpeg-turbo-devel \
+          pixman-devel libpng-devel SDL2-devel SDL2_image-devel tinyxml2-devel \
+          zlib-devel nodejs-devel libarchive-devel libXi-devel libXcursor-devel
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Get short commit hash
+      id: commit
+      run: echo "short_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Update config.h with commit hash
+      run: sed -i 's/"local build"/"${{ steps.commit.outputs.short_hash }}"/g' src/config.h
+    - name: Configure
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON \
+          -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON \
+          -DBESPRITED_PACKAGE_VERSION="$VERSION"
+    - name: Build the binaries
+      run: |
+        ninja -C build besprited
+        rm build/bin/gen
+    - name: Package the .rpm
+      id: rpm
+      run: |
+        cpack -G RPM --config build/CPackConfig.cmake -B build
+        RPM=$(ls build/*.rpm | head -n1)
+        rpm -qip "$RPM"
+        rpm -qlp "$RPM"
+        mv "$RPM" .
+        echo "rpm=$(basename "$RPM")" >> $GITHUB_OUTPUT
+    - name: Upload .rpm artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: besprited-${{ github.ref_name }}-linux-x86_64-rpm
+        path: ${{ steps.rpm.outputs.rpm }}
         if-no-files-found: error

--- a/.github/workflows/cmakeLinux.yml
+++ b/.github/workflows/cmakeLinux.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         mkdir build
         if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON -DWITH_DESKTOP_INTEGRATION=ON
         else
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_DESKTOP_INTEGRATION=ON
         fi
     - name: Build the binaries
       run: |
@@ -70,26 +70,6 @@ jobs:
         name: ${{ steps.check_tag.outputs.has_tag == 'true' && format('besprited-{0}-linux-x86_64-tarball', steps.check_tag.outputs.tag) || 'besprited-linux-x86_64-tarball' }}
         path: ${{ steps.tarball.outputs.tarball }}
         if-no-files-found: error
-    - name: Package the .deb
-      id: deb
-      run: |
-        VERSION="${{ steps.check_tag.outputs.tag }}"
-        VERSION="${VERSION#v}"
-        [ -n "$VERSION" ] || VERSION="0.0.0"
-        cmake -S . -B build -DBESPRITED_PACKAGE_VERSION="$VERSION"
-        cpack -G DEB --config build/CPackConfig.cmake -B build
-        DEB=$(ls build/*.deb | head -n1)
-        dpkg --info "$DEB"
-        dpkg -c "$DEB"
-        mv "$DEB" .
-        echo "deb=$(basename "$DEB")" >> $GITHUB_OUTPUT
-    - name: Upload .deb artifact
-      if: runner.arch == 'X64' && steps.check_tag.outputs.has_tag == 'true'
-      uses: actions/upload-artifact@v7
-      with:
-        name: besprited-${{ steps.check_tag.outputs.tag }}-linux-amd64-deb
-        path: ${{ steps.deb.outputs.deb }}
-        if-no-files-found: error
     - name: Package the AppImage
       run: |
         export ARCH="$(uname -m)"
@@ -101,6 +81,70 @@ jobs:
       with:
         name: ${{ steps.check_tag.outputs.has_tag == 'true' && format('besprited-{0}-linux-x86_64', steps.check_tag.outputs.tag) || 'besprited-linux-x86_64' }}
         path: Besprited-anylinux-x86_64.AppImage
+        if-no-files-found: error
+
+  # A .deb links against whatever library SONAMEs its build distro ships and
+  # dpkg-shlibdeps pins the matching package names, so a single .deb can't span
+  # releases (e.g. libtinyxml2-10 vs -11, libjpeg.so.8 vs .so.62). Build one per
+  # target distro inside its own container.
+  package-deb:
+    name: Package .deb (${{ matrix.distro }})
+    runs-on: ubuntu-26.04
+    container: ${{ matrix.image }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, 'NO_SW_CHANGE') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: 'debian:13',    distro: debian13 }
+          - { image: 'ubuntu:24.04', distro: ubuntu24.04 }
+          - { image: 'ubuntu:26.04', distro: ubuntu26.04 }
+    steps:
+    - name: Install build dependencies
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          g++ ninja-build git ca-certificates dpkg-dev file python3-pip \
+          libcurl4-gnutls-dev libfreetype-dev libgif-dev libjpeg-dev libpixman-1-dev \
+          libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libnode-dev \
+          zlib1g-dev libarchive-dev libx11-dev libxcursor-dev libxi-dev
+        # Distro CMake is < 4.1; the project needs >= 4.1 (matches the main job).
+        pip install --break-system-packages cmake
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Get short commit hash
+      id: commit
+      run: echo "short_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Update config.h with commit hash
+      run: sed -i 's/"local build"/"${{ steps.commit.outputs.short_hash }}"/g' src/config.h
+    - name: Configure
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON \
+          -DWITH_DESKTOP_INTEGRATION=ON -DENABLE_PACKAGING=ON \
+          -DBESPRITED_PACKAGE_VERSION="$VERSION"
+    - name: Build the binaries
+      run: |
+        ninja -C build besprited
+        rm build/bin/gen
+    - name: Package the .deb
+      id: deb
+      run: |
+        cpack -G DEB --config build/CPackConfig.cmake -B build
+        NAMED="besprited_${GITHUB_REF_NAME#v}_${{ matrix.distro }}_amd64.deb"
+        mv "$(ls build/*.deb | head -n1)" "$NAMED"
+        dpkg --info "$NAMED"
+        echo "Depends: $(dpkg-deb -f "$NAMED" Depends)"
+        echo "deb=$NAMED" >> $GITHUB_OUTPUT
+    - name: Upload .deb artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: besprited-${{ github.ref_name }}-${{ matrix.distro }}-deb
+        path: ${{ steps.deb.outputs.deb }}
         if-no-files-found: error
 
   # Build the .rpm inside an actual Fedora environment so the auto-detected

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,9 @@ if(ENABLE_PACKAGING)
   set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Veritaware/Besprited")
   set(CPACK_PACKAGE_DESCRIPTION
       "Besprited is a free and open source program for creating and animating 2D sprites.")
+  # CPack's DEB/RPM generators don't fall back to CPACK_PACKAGE_DESCRIPTION.
+  set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
+  set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
   set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
   set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
   set(CPACK_STRIP_FILES ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(WITH_QT_THUMBNAILER          "Enable kde5/qt5 thumnailer" off)
 option(ENABLE_MEMLEAK     "Enable memory-leaks detector (only for developers)" off)
 option(ENABLE_TESTS       "Enable the unit tests" off)
 option(FULLSCREEN_PLATFORM "Enable fullscreen by default" off)
+option(ENABLE_PACKAGING   "Configure CPack for .deb/.rpm package generation" off)
 
 option(USE_SDL2_BACKEND "Use SDL2 backend" on)
 
@@ -402,4 +403,76 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   message(STATUS "GCC compiler found: ${CMAKE_CXX_COMPILER}")
 else()
   message(STATUS "GCC compiler not found - target 'gcc-analyzer' will not be available")
+endif()
+
+######################################################################
+# Packaging (CPack)
+#
+# Only wired up when ENABLE_PACKAGING is set, so normal development builds are
+# unaffected. Reuses the existing install() rules; build with
+# -DWITH_DESKTOP_INTEGRATION=ON to also package the .desktop/icons/metainfo/mime
+# files. Produces a .deb (CPack "DEB" generator) and/or a .rpm ("RPM").
+
+if(ENABLE_PACKAGING)
+  # Version: passed explicitly by CI (the release tag, without a leading "v"),
+  # otherwise parsed from the release VERSION in src/config.h.
+  set(BESPRITED_PACKAGE_VERSION "" CACHE STRING "Version string for generated packages")
+  if(NOT BESPRITED_PACKAGE_VERSION)
+    file(READ "${CMAKE_SOURCE_DIR}/src/config.h" _besprited_config_h)
+    string(REGEX MATCH "VERSION \"([0-9]+\\.[0-9]+\\.[0-9]+)\"" _ "${_besprited_config_h}")
+    if(CMAKE_MATCH_1)
+      set(BESPRITED_PACKAGE_VERSION "${CMAKE_MATCH_1}")
+    else()
+      set(BESPRITED_PACKAGE_VERSION "0.0.0")
+    endif()
+    unset(_besprited_config_h)
+  endif()
+  message(STATUS "Packaging enabled - package version ${BESPRITED_PACKAGE_VERSION}")
+
+  set(CPACK_PACKAGE_NAME "besprited")
+  set(CPACK_PACKAGE_VENDOR "Veritaware")
+  set(CPACK_PACKAGE_VERSION "${BESPRITED_PACKAGE_VERSION}")
+  if(BESPRITED_PACKAGE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(CPACK_PACKAGE_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(CPACK_PACKAGE_VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(CPACK_PACKAGE_VERSION_PATCH "${CMAKE_MATCH_3}")
+  endif()
+  set(CPACK_PACKAGE_CONTACT "Veritaware <https://github.com/Veritaware/Besprited/issues>")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Animated sprite editor & pixel art tool")
+  set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Veritaware/Besprited")
+  set(CPACK_PACKAGE_DESCRIPTION
+      "Besprited is a free and open source program for creating and animating 2D sprites.")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+  set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+  set(CPACK_STRIP_FILES ON)
+  set(CPACK_PACKAGE_FILE_NAME
+      "besprited-${CPACK_PACKAGE_VERSION}-${CMAKE_SYSTEM_PROCESSOR}")
+
+  # --- Debian/Ubuntu (.deb) ---
+  set(CPACK_DEBIAN_PACKAGE_SECTION "graphics")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_CONTACT}")
+  set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_PACKAGE_HOMEPAGE_URL}")
+  # Auto-resolve runtime Depends: from the linked shared libraries.
+  set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+  set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+
+  # --- Fedora/RHEL (.rpm) ---
+  set(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
+  set(CPACK_RPM_PACKAGE_GROUP "Applications/Multimedia")
+  set(CPACK_RPM_PACKAGE_URL "${CPACK_PACKAGE_HOMEPAGE_URL}")
+  set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
+  # rpmbuild derives Requires: automatically by scanning the ELF NEEDED entries.
+  set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+  # Don't let the package claim ownership of directories owned by the distro's
+  # own filesystem/hicolor-icon-theme/shared-mime-info packages.
+  set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
+      /usr/share/applications
+      /usr/share/icons
+      /usr/share/icons/hicolor
+      /usr/share/metainfo
+      /usr/share/mime
+      /usr/share/mime/packages
+      /usr/share/thumbnailers)
+
+  include(CPack)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,7 @@ if(ENABLE_PACKAGING)
     set(CPACK_PACKAGE_VERSION_MINOR "${CMAKE_MATCH_2}")
     set(CPACK_PACKAGE_VERSION_PATCH "${CMAKE_MATCH_3}")
   endif()
-  set(CPACK_PACKAGE_CONTACT "Veritaware <https://github.com/Veritaware/Besprited/issues>")
+  set(CPACK_PACKAGE_CONTACT "Daniel Praźmo <d.prazmo@icloud.com>")
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Animated sprite editor & pixel art tool")
   set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/Veritaware/Besprited")
   set(CPACK_PACKAGE_DESCRIPTION

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,9 +20,16 @@
 
 You can download installers from the [releases page](https://github.com/Veritaware/Besprited/releases).
 
-On Linux you have two prebuilt options:
+On Linux you have several prebuilt options:
 
 * **AppImage** – a single self-contained executable. You need `libfuse2` installed to run it.
+* **Native packages** – `.deb` for Debian/Ubuntu and `.rpm` for Fedora, with dependencies
+  resolved by the package manager. The `.deb` is built per distro release (its library
+  dependencies are release-specific), so pick the one matching your system –
+  `besprited_<version>_debian13_amd64.deb`, `..._ubuntu24.04_amd64.deb` (also covers Linux
+  Mint 22), `..._ubuntu26.04_amd64.deb` – and install it with
+  `sudo apt install ./besprited_<version>_<distro>_amd64.deb` or
+  `sudo dnf install ./besprited-<version>-1.x86_64.rpm`.
 * **`.tar.gz` package** – a portable FHS tree (`besprited-<version>-linux-<arch>.tar.gz`) with a
   bundled installer. Extract it and run the install script from the extracted directory:
 


### PR DESCRIPTION
Implements #161 — `.deb` and `.rpm` generation via CMake's built-in CPack `DEB` / `RPM` generators, reusing the existing `install()` rules.

## Changes

### `CMakeLists.txt`
- New `ENABLE_PACKAGING` option (off by default — normal dev builds are untouched). When on, it sets the CPack config and calls `include(CPack)`:
  - Common: `CPACK_PACKAGE_NAME "besprited"`, version, `/usr` install prefix, contact, `LICENSE.txt`, summary/description, strip.
  - Version comes from `-DBESPRITED_PACKAGE_VERSION` (the release tag without a leading `v`, passed by CI) or, absent that, is parsed from the release `VERSION` in `src/config.h`.
  - Debian: `graphics` section, `CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON` (auto `Depends:` via `dpkg-shlibdeps`), `DEB-DEFAULT` filename, homepage.
  - RPM: `GPLv2` license, `Applications/Multimedia` group, `AUTOREQ ON` (rpmbuild ELF scan), `RPM-DEFAULT` filename, and `CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION` for `/usr/share/{applications,icons,icons/hicolor,metainfo,mime,mime/packages,thumbnailers}` so the package doesn't fight `filesystem` / `hicolor-icon-theme` / `shared-mime-info` for directory ownership.

### `.github/workflows/cmakeLinux.yml`
- Existing `build` job configures with `-DENABLE_PACKAGING=ON`, then a **Package the .deb** step runs `cpack -G DEB` and prints `dpkg --info` / `dpkg -c`. It runs on every push/PR for validation; the artifact is uploaded only on tags.
- New **`package-rpm`** job (`container: fedora:latest`, tags only) installs the Fedora deps from `INSTALL.md`, builds, runs `cpack -G RPM`, prints `rpm -qip` / `rpm -qlp`, and uploads the `.rpm`. Building inside real Fedora keeps the auto-detected `Requires:` and library layout trustworthy rather than cross-packaging from Ubuntu.

### `.github/actions/install-deps/action.yml`
- Adds `dpkg-dev` (provides `dpkg-shlibdeps`).

## Testing
- Configured with `-DENABLE_PACKAGING=ON` locally; CPack generates the staging tree with the correct `/usr` prefix (`/usr/bin/besprited`, `/usr/share/besprited/data/...`, `/usr/share/applications`, icons, metainfo, mime, thumbnailers). `resource_finder.cpp`'s `../share/besprited/data` path resolves from `/usr/bin`.
- `cpack -G DEB` runs and emits a `.deb`; dep resolution / arch detection need the Debian toolchain and are exercised on the Ubuntu runner. `.rpm` is exercised by the Fedora CI job.
- `dpkg -c` / `dpkg --info` (deb) and `rpm -qip` / `rpm -qlp` (rpm) are printed in CI for inspection per the ticket's verification step.
- Manual `apt install ./besprited_*.deb` / `dnf install ./besprited-*.rpm` in clean containers still recommended before a release (per the ticket) — not doable in this CI.

## Note for the maintainer
`CPACK_PACKAGE_CONTACT` is set to `Veritaware <https://github.com/Veritaware/Besprited/issues>` since there's no published maintainer email in the repo. Swap in a real `Name <email>` if you want a cleaner `lintian`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
