### PR TITLE
Guess first-run UI scale from the real screen size

### DIFF
--- a/src/app/modules/gui.cpp
+++ b/src/app/modules/gui.cpp
@@ -1,5 +1,6 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C) 2021       LibreSprite contributors
+// Besprited   | Copyright (C) 2026       Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -195,7 +196,18 @@ int init_module_gui()
 	  #ifdef EMSCRIPTEN
 	  uiScale = 2;
 	  #else
-          uiScale = 2 + (ui::display_h() > 400) + (ui::display_h() > 800);
+	  // Guess a sensible UI scale on the first run from the primary
+	  // display's resolution, keeping the post-scale (logical) screen
+	  // height usable for the editor (~400px is the practical minimum).
+	  // The initial window is only a small fallback size, so prefer the
+	  // real desktop height and only fall back to the window height when
+	  // it's unavailable. Note: on Hi-DPI setups SDL may report either
+	  // pixels or points depending on the platform, so the thresholds are
+	  // deliberately conservative.
+	  int screenH = she::instance()->desktopSize().h;
+	  if (screenH <= 0)
+	      screenH = ui::display_h();
+	  uiScale = MID(1, 1 + (screenH >= 720) + (screenH >= 1200) + (screenH >= 1800), 4);
 	  #endif
           Preferences::instance().experimental.uiScale(uiScale);
       }

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -862,6 +862,19 @@ namespace she {
       return gfx::Size(0, 0);
     }
 
+    gfx::Size desktopSize() override {
+      // Reports the primary display's resolution in pixels (or in points on
+      // platforms where the window is not created high-DPI aware, e.g. macOS
+      // without SDL_WINDOW_ALLOW_HIGHDPI). Returns (0, 0) when SDL can't
+      // determine it or the video subsystem isn't up yet.
+      if (SDL_WasInit(SDL_INIT_VIDEO) == 0)
+        return gfx::Size(0, 0);
+      SDL_DisplayMode mode;
+      if (SDL_GetDesktopDisplayMode(0, &mode) != 0)
+        return gfx::Size(0, 0);
+      return gfx::Size(mode.w, mode.h);
+    }
+
     Display* defaultDisplay() override {
       return unique_display;
     }

--- a/src/she/system.h
+++ b/src/she/system.h
@@ -1,5 +1,6 @@
 // SHE library
 // Copyright (C) 2012-2016  David Capello
+// Copyright (C) 2026       Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -42,6 +43,8 @@ namespace she {
     virtual bool gpuAcceleration() const = 0;
     virtual void setGpuAcceleration(bool state) = 0;
     virtual gfx::Size defaultNewDisplaySize() = 0;
+    // Primary display resolution in pixels, or (0,0) if it can't be determined.
+    virtual gfx::Size desktopSize() = 0;
     virtual Display* defaultDisplay() = 0;
     virtual Display* createDisplay(int width, int height, int scale) = 0;
     virtual Surface* createSurface(int width, int height) = 0;


### PR DESCRIPTION
Fixes #167.

## Problem

On the first launch the UI-element scale is set to **300%** on essentially every machine, including 1280×800 screens that can only comfortably fit 200%.

## Cause

`init_module_gui()` guessed the scale with:

```cpp
uiScale = 2 + (ui::display_h() > 400) + (ui::display_h() > 800);
```

At that point the main window is whatever `create_main_display()` managed to open. On a first run there is no saved geometry and `she::System::defaultNewDisplaySize()` returns `(0,0)`, so it falls back to the `try_resolutions` list and opens at **1024×768**. `display_h()` is therefore ~768 for everyone → `2 + 1 + 0 = 3` → 300%, regardless of the actual monitor.

## Fix

- Add `she::System::desktopSize()` — the primary display resolution in pixels, via `SDL_GetDesktopDisplayMode` (returns `(0,0)` if the video subsystem isn't up or SDL can't tell).
- Guess the scale from that instead of the fallback window height, with more conservative breakpoints:

  | Screen height | Scale |
  | --- | --- |
  | `< 720` | 100% |
  | `720–1199` | 200% |
  | `1200–1799` | 300% |
  | `≥ 1800` | 400% |

  Falls back to the old window-height source only when `desktopSize()` is unavailable. Clamped to 1–4×. The `EMSCRIPTEN` path is unchanged.

A 1280×800 screen now gets 200%; 1440p gets 300%; 4K gets 400%.

## Hi-DPI note

SDL reports desktop size in **pixels** on Windows (the app sets `permonitorv2` DPI awareness) and X11, but in **points** on macOS because the window is not created with `SDL_WINDOW_ALLOW_HIGHDPI`. The thresholds are deliberately conservative to stay reasonable under both. Properly honoring per-monitor OS scaling factors (`SDL_GetDisplayDPI`) would be a larger change and `SDL_GetDisplayDPI` is unreliable on Linux — left for a follow-up.

## Testing

- `ninja besprited` builds clean.
- Traced the value manually for the resolutions in the issue; a full clean-profile launch check on each OS still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)