### PR TITLE
Strip non-editor .exe files from the Windows package

### DIFF
--- a/.github/workflows/cmakeWin64.yml
+++ b/.github/workflows/cmakeWin64.yml
@@ -77,7 +77,9 @@ jobs:
       shell: msys2 {0}
       run: |
         make -C build -j 4
-        rm build/bin/gen.exe
+        # Keep only the editor executable - drop gen.exe, qjs/qjsc, *_tests, etc.
+        # so they never end up in the portable ZIP or the installer.
+        find build/bin -maxdepth 1 -type f -name '*.exe' ! -name 'besprited.exe' -delete
         node packaging/package_win.js build/bin/besprited.exe
     - name: Upload portable archive
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What

The Windows build step only removed `gen.exe` before packaging, so `qjs.exe` / `qjsc.exe`, the `*_tests.exe` binaries and any other tools built into `build/bin/` were:

- uploaded in the `besprited-*-windows-x86_64` portable-archive artifact, and
- swept into the Inno Setup installer (which packages `build/bin/`).

## Change

Replace `rm build/bin/gen.exe` with:

```sh
find build/bin -maxdepth 1 -type f -name '*.exe' ! -name 'besprited.exe' -delete
```

Runs right after `make`, before `package_win.js` copies the runtime DLLs next to `besprited.exe`, so the portable ZIP and the installer both contain only the editor plus its DLLs. DLLs and data are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)