### PR TITLE
Add test coverage for base infrastructure classes

### DIFF
--- a/src/base/injection.h
+++ b/src/base/injection.h
@@ -1,5 +1,6 @@
 // Aseprite Base Library
-// Copyright (c) 2021 LibreSprite contributors
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
+// Besprited   | Copyright (C) 2026       Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -188,10 +189,10 @@ public:
     std::swap(onDetach, other.onDetach);
   }
 
-  BaseClass* operator -> () {return m_ptr;}
-  BaseClass& operator * () {return *m_ptr;}
-  operator bool () {return m_ptr;}
-  operator BaseClass* () {return m_ptr;}
+  BaseClass* operator -> () const {return m_ptr;}
+  BaseClass& operator * () const {return *m_ptr;}
+  operator bool () const {return m_ptr;}
+  operator BaseClass* () const {return m_ptr;}
 
   template<typename Derived = BaseClass>
   Derived* get() const {return dynamic_cast<Derived*>(m_ptr);}

--- a/src/base/injection.h
+++ b/src/base/injection.h
@@ -1,6 +1,6 @@
-// Aseprite Base Library
-// LibreSprite | Copyright (C) 2021       LibreSprite contributors
-// Besprited   | Copyright (C) 2026       Veritaware
+// Base Library
+// LibreSprite | Copyright (C) 2021 LibreSprite contributors
+// Besprited   | Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/base/safe_ptr.h
+++ b/src/base/safe_ptr.h
@@ -1,5 +1,5 @@
-// LibreSprite | Copyright (C) 2021       LibreSprite contributors
-// Besprited   | Copyright (C) 2026       Veritaware
+// LibreSprite | Copyright (C) 2021 LibreSprite contributors
+// Besprited   | Copyright (C) 2026 Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/base/safe_ptr.h
+++ b/src/base/safe_ptr.h
@@ -1,5 +1,5 @@
-// LibreSprite
-// Copyright (C) 2021 LibreSprite contributors
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
+// Besprited   | Copyright (C) 2026       Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -90,8 +90,21 @@ namespace base {
       return **storage;
     }
 
-    template<typename T>
+    // Only participates in overload resolution for scalar targets (bool,
+    // other pointer types, integers, enums...). Without this constraint the
+    // operator is a universal implicit conversion candidate for *any* class
+    // type T, which some SFINAE-heavy code (e.g. GoogleTest's
+    // AssertionResult, whose constructors probe std::is_convertible<...,
+    // AssertionResult> while overload-resolving an implicit bool
+    // conversion) ends up instantiating in ways that are unrelated to the
+    // caller's intent and unsafe to evaluate eagerly.
+    template<typename T,
+             typename std::enable_if<std::is_scalar<T>::value, int>::type = 0>
     operator T () const {
+      // Guard against dereferencing empty/expired storage, same as
+      // operator bool() above.
+      if (!storage || !*storage)
+        return T{};
       return static_cast<T>(*storage);
     }
 
@@ -130,7 +143,13 @@ namespace base {
 
   template<typename Type>
   void saveSafePtr(Type* raw, safe_ptr<Type> safe) {
-    detail::getSafePtrIndex<Type>().emplace(raw, safe);
+    // Overwrite, don't emplace: a dead entry can still be sitting at `raw`
+    // if the heap reused a previously make_safe()'d object's address
+    // before a purgeSafePtrs() ran. emplace() would silently keep that
+    // stale (dead) entry instead of registering the new, live object.
+    // insert_or_assign() (rather than operator[]) avoids requiring
+    // safe_ptr<Type> to be default-constructible, which it isn't.
+    detail::getSafePtrIndex<Type>().insert_or_assign(raw, safe);
   }
 
   template<typename Type>

--- a/test/base/fs_tests.cpp
+++ b/test/base/fs_tests.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "base/fs.h"
+#include "base/path.h"
 
 using namespace base;
 
@@ -42,6 +43,63 @@ TEST(FileSystem, MakeAllDirectories)
 
   remove_directory("a");
   EXPECT_FALSE(is_directory("a"));
+}
+
+TEST(FileSystem, ListFilesOnAnEmptyDirectory)
+{
+  make_directory("list_a");
+  auto files = list_files("list_a");
+  EXPECT_TRUE(files.empty());
+  remove_directory("list_a");
+}
+
+TEST(FileSystem, ListFilesExcludesDotAndDotDot)
+{
+  make_all_directories("list_b/child");
+  auto files = list_files("list_b");
+
+  ASSERT_EQ(1u, files.size());
+  EXPECT_EQ("child", files[0]);
+  for (auto& name : files) {
+    EXPECT_NE(".", name);
+    EXPECT_NE("..", name);
+  }
+
+  remove_directory("list_b/child");
+  remove_directory("list_b");
+}
+
+TEST(FileSystem, ListFilesOnAMissingDirectoryReturnsEmpty)
+{
+  EXPECT_FALSE(is_directory("does_not_exist_dir"));
+  auto files = list_files("does_not_exist_dir");
+  EXPECT_TRUE(files.empty());
+}
+
+TEST(FileSystem, GetCanonicalPathResolvesTheCurrentDirectory)
+{
+  make_directory("canon_dir");
+
+  auto canonical = get_canonical_path("canon_dir");
+
+  // Must be turned into an absolute path.
+  EXPECT_TRUE(is_path_separator(canonical.front()) ||
+              (canonical.size() > 1 && canonical[1] == ':'));
+  EXPECT_TRUE(is_directory(canonical));
+
+  remove_directory("canon_dir");
+}
+
+TEST(FileSystem, GetCanonicalPathOnAMissingPathReturnsItUnchanged)
+{
+  std::string missing = "this_path_does_not_exist_at_all";
+  EXPECT_EQ(missing, get_canonical_path(missing));
+}
+
+TEST(FileSystem, GetFontPathsIsNonEmpty)
+{
+  auto paths = get_font_paths();
+  EXPECT_FALSE(paths.empty());
 }
 
 int main(int argc, char** argv)

--- a/test/base/injection_tests.cpp
+++ b/test/base/injection_tests.cpp
@@ -1,0 +1,207 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include <gtest/gtest.h>
+
+#include "base/injection.h"
+
+#include <set>
+#include <string>
+
+namespace {
+
+// --- Regular vs Singleton policies -----------------------------------
+
+int g_stdoutAlive = 0;
+
+struct Logger : public Injectable<Logger> {
+  virtual ~Logger() = default;
+  virtual std::string speak() = 0;
+};
+
+struct StdoutLogger : public Logger {
+  StdoutLogger() { ++g_stdoutAlive; }
+  ~StdoutLogger() override { --g_stdoutAlive; }
+  std::string speak() override { return "stdout"; }
+};
+Logger::Regular<StdoutLogger> g_regStdout{"stdout"};
+
+struct FileLogger : public Logger {
+  std::string speak() override { return "file"; }
+};
+Logger::Singleton<FileLogger> g_regFile{"file"};
+
+// --- Provides policy ----------------------------------------------------
+
+struct Account : public Injectable<Account> {
+  virtual ~Account() = default;
+  virtual int amount() = 0;
+};
+
+struct RealAccount : public Account {
+  int amount() override { return 100; }
+};
+
+// --- setDefault / flags / getAll ----------------------------------------
+
+struct Thing : public Injectable<Thing> {
+  virtual ~Thing() = default;
+  virtual std::string id() = 0;
+};
+
+struct ThingA : public Thing {
+  std::string id() override { return "A"; }
+};
+
+struct ThingB : public Thing {
+  std::string id() override { return "B"; }
+};
+
+Thing::Regular<ThingA> g_regA{"a", {"flagA"}};
+Thing::Regular<ThingB> g_regB{"b", {"flagB"}};
+
+// --- inject<>::get<Derived>() dynamic_cast --------------------------------
+
+struct Base2 : public Injectable<Base2> {
+  virtual ~Base2() = default;
+};
+
+struct Derived2 : public Base2 {
+  int val = 3;
+};
+
+Base2::Regular<Derived2> g_regDerived{"derived"};
+
+} // namespace
+
+TEST(Injection, RegularCreatesAFreshOwnedInstancePerInject)
+{
+  g_stdoutAlive = 0;
+  {
+    inject<Logger> a{"stdout"};
+    EXPECT_EQ(1, g_stdoutAlive);
+
+    inject<Logger> b{"stdout"};
+    EXPECT_EQ(2, g_stdoutAlive);
+
+    EXPECT_NE(static_cast<Logger*>(a), static_cast<Logger*>(b));
+    EXPECT_EQ("stdout", a->speak());
+  }
+  // Both injects went out of scope: Regular's onDetach deletes the instance.
+  EXPECT_EQ(0, g_stdoutAlive);
+}
+
+TEST(Injection, SingletonReturnsTheSameInstanceEveryTime)
+{
+  inject<Logger> a{"file"};
+  inject<Logger> b{"file"};
+
+  ASSERT_TRUE(a);
+  ASSERT_TRUE(b);
+  EXPECT_EQ(static_cast<Logger*>(a), static_cast<Logger*>(b));
+  EXPECT_EQ("file", a->speak());
+}
+
+TEST(Injection, ProvidesRegistersAndUnregistersOnDestruction)
+{
+  {
+    RealAccount acc;
+    Account::Provides p{&acc}; // registers under the default ("") name
+
+    inject<Account> viaDefault;
+    ASSERT_TRUE(viaDefault);
+    EXPECT_EQ(100, viaDefault->amount());
+  }
+  // `p` went out of scope above, unregistering the default entry.
+  inject<Account> afterScope;
+  EXPECT_FALSE(afterScope);
+}
+
+TEST(Injection, SetDefaultByNameSelectsThatEntry)
+{
+  ASSERT_TRUE(Thing::setDefault("a"));
+  inject<Thing> def{""};
+  ASSERT_TRUE(def);
+  EXPECT_EQ("A", def->id());
+
+  ASSERT_TRUE(Thing::setDefault("b"));
+  inject<Thing> def2{""};
+  ASSERT_TRUE(def2);
+  EXPECT_EQ("B", def2->id());
+}
+
+TEST(Injection, SetDefaultByFlagSelectsAMatchingEntry)
+{
+  ASSERT_TRUE(Thing::setDefault("does-not-exist-as-a-name", {"flagB"}));
+  inject<Thing> def{""};
+  ASSERT_TRUE(def);
+  EXPECT_EQ("B", def->id());
+}
+
+TEST(Injection, SetDefaultFailsWithNoNameMatchAndNoFlagMatch)
+{
+  EXPECT_FALSE(Thing::setDefault("nope", {"no-such-flag"}));
+}
+
+TEST(Injection, GetAllReturnsEveryNamedEntryOnceExcludingTheDefaultAlias)
+{
+  auto all = Thing::getAll();
+
+  std::set<std::string> ids;
+  for (auto& inj : all)
+    ids.insert(inj->id());
+
+  // "a" and "b" only; the "" alias created by setDefault() must not
+  // duplicate one of them.
+  EXPECT_EQ(2u, ids.size());
+  EXPECT_EQ(1u, ids.count("A"));
+  EXPECT_EQ(1u, ids.count("B"));
+}
+
+TEST(Injection, GetAllWithFlagFiltersByFlag)
+{
+  auto onlyB = Thing::getAllWithFlag("flagB");
+  ASSERT_EQ(1u, onlyB.size());
+  EXPECT_EQ("B", onlyB[0]->id());
+
+  auto none = Thing::getAllWithFlag("no-such-flag");
+  EXPECT_TRUE(none.empty());
+}
+
+TEST(Injection, UnknownNameYieldsANullInject)
+{
+  inject<Thing> missing{"this-name-was-never-registered"};
+  EXPECT_FALSE(missing);
+  EXPECT_EQ(nullptr, missing.get<Thing>());
+}
+
+TEST(Injection, NullptrConstructionYieldsAnInvalidInject)
+{
+  inject<Logger> i{nullptr};
+  EXPECT_FALSE(i);
+}
+
+TEST(Injection, InjectIsMovable)
+{
+  inject<Logger> a{"stdout"};
+  Logger* raw = a;
+
+  inject<Logger> b{std::move(a)};
+  EXPECT_EQ(raw, static_cast<Logger*>(b));
+}
+
+TEST(Injection, InjectGetTemplateDynamicCastsToADerivedType)
+{
+  inject<Base2> i{"derived"};
+  Derived2* d = i.get<Derived2>();
+  ASSERT_NE(nullptr, d);
+  EXPECT_EQ(3, d->val);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/base/injection_tests.cpp
+++ b/test/base/injection_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/base/path_tests.cpp
+++ b/test/base/path_tests.cpp
@@ -148,6 +148,29 @@ TEST(Path, CompareFilenames)
   EXPECT_EQ(1, compare_filenames("a1-64-10.png", "a1-64-9.png"));
 }
 
+TEST(Path, VerifyFilename)
+{
+  // verify_filename() only rejects characters on Windows (where _wfopen()
+  // would choke on them); elsewhere every filename is accepted.
+#ifdef _WIN32
+  EXPECT_EQ(std::string::npos, verify_filename("normal_name.png"));
+  EXPECT_EQ(0u, verify_filename(":bad"));
+  EXPECT_EQ(1u, verify_filename("a?bad"));
+  EXPECT_EQ(1u, verify_filename("a\"bad"));
+  EXPECT_EQ(1u, verify_filename("a<bad"));
+  EXPECT_EQ(1u, verify_filename("a>bad"));
+  EXPECT_EQ(1u, verify_filename("a|bad"));
+  EXPECT_EQ(1u, verify_filename("a*bad"));
+  // Slashes and backslashes are intentionally left to _wfopen() itself.
+  EXPECT_EQ(std::string::npos, verify_filename("a/b\\c"));
+  EXPECT_EQ(std::string::npos, verify_filename(""));
+#else
+  EXPECT_EQ(std::string::npos, verify_filename("normal_name.png"));
+  EXPECT_EQ(std::string::npos, verify_filename(":bad?name<with>weird|chars*"));
+  EXPECT_EQ(std::string::npos, verify_filename(""));
+#endif
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/base/range_tests.cpp
+++ b/test/base/range_tests.cpp
@@ -1,0 +1,45 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include <gtest/gtest.h>
+
+#include "base/range.h"
+
+#include <vector>
+
+TEST(Range, IteratesTheUnderlyingContainer)
+{
+  std::vector<int> values{1, 2, 3, 4};
+  base::range<std::vector<int>::iterator> r{{values.begin(), values.end()}};
+
+  std::vector<int> collected;
+  for (int v : r)
+    collected.push_back(v);
+
+  EXPECT_EQ(values, collected);
+}
+
+TEST(Range, EmptyWhenBeginEqualsEnd)
+{
+  std::vector<int> values{1, 2, 3};
+  base::range<std::vector<int>::iterator> r{{values.begin(), values.begin()}};
+
+  EXPECT_TRUE(r.empty());
+  EXPECT_EQ(r.begin(), r.end());
+}
+
+TEST(Range, NotEmptyWhenThereAreElements)
+{
+  std::vector<int> values{1};
+  base::range<std::vector<int>::iterator> r{{values.begin(), values.end()}};
+
+  EXPECT_FALSE(r.empty());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/base/range_tests.cpp
+++ b/test/base/range_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/base/safe_ptr_tests.cpp
+++ b/test/base/safe_ptr_tests.cpp
@@ -1,0 +1,182 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include <gtest/gtest.h>
+
+#include "base/safe_ptr.h"
+
+using namespace base;
+
+namespace {
+
+// A plain type using the manually-embedded safe_ptr pattern described in
+// safe_ptr.h's header comment.
+struct Manual {
+  base::safe_ptr<Manual> ptr{this};
+  int value = 42;
+};
+
+// A type with a virtual destructor, usable with base::make_safe().
+struct Virtual {
+  virtual ~Virtual() = default;
+  int value = 7;
+};
+
+} // namespace
+
+TEST(SafePtr, NullConstruction)
+{
+  safe_ptr<Manual> p{nullptr};
+  EXPECT_FALSE(p);
+}
+
+TEST(SafePtr, BecomesNullWhenOwnerDestroyed)
+{
+  auto* obj = new Manual();
+  safe_ptr<Manual> copy = obj->ptr;
+
+  EXPECT_TRUE(copy);
+  EXPECT_EQ(42, copy->value);
+
+  delete obj;
+
+  EXPECT_FALSE(copy);
+}
+
+TEST(SafePtr, CopiesShareTheSameStorage)
+{
+  auto* obj = new Manual();
+  safe_ptr<Manual> a = obj->ptr;
+  safe_ptr<Manual> b = a;
+  safe_ptr<Manual> c{nullptr};
+  c = b;
+
+  EXPECT_TRUE(a);
+  EXPECT_TRUE(b);
+  EXPECT_TRUE(c);
+
+  delete obj;
+
+  EXPECT_FALSE(a);
+  EXPECT_FALSE(b);
+  EXPECT_FALSE(c);
+}
+
+TEST(SafePtr, MoveKeepsValidity)
+{
+  auto* obj = new Manual();
+  safe_ptr<Manual> a = obj->ptr;
+  safe_ptr<Manual> b{nullptr};
+  b = std::move(a);
+
+  EXPECT_TRUE(b);
+  EXPECT_EQ(42, b->value);
+
+  delete obj;
+
+  EXPECT_FALSE(b);
+}
+
+TEST(SafePtr, GetReturnsRawPointerWhileAlive)
+{
+  auto* obj = new Manual();
+  safe_ptr<Manual> p = obj->ptr;
+
+  EXPECT_EQ(obj, p.get());
+
+  delete obj;
+}
+
+TEST(SafePtr, MakeSafeOwnsAVirtualDtorInstance)
+{
+  auto safe = base::make_safe<Virtual>();
+  ASSERT_TRUE(safe);
+  EXPECT_EQ(7, safe->value);
+
+  auto copy = safe;
+  EXPECT_TRUE(copy);
+
+  delete safe.get();
+
+  EXPECT_FALSE(safe);
+  EXPECT_FALSE(copy);
+}
+
+TEST(SafePtr, FindSafePtrReturnsNullForUnknownRawPointer)
+{
+  Manual stackObj;
+  auto found = base::findSafePtr(&stackObj);
+  EXPECT_FALSE(found);
+}
+
+TEST(SafePtr, FindSafePtrReturnsRegisteredCopy)
+{
+  auto safe = base::make_safe<Virtual>();
+  auto* raw = safe.get();
+
+  auto found = base::findSafePtr(raw);
+  ASSERT_TRUE(found);
+  EXPECT_EQ(raw, found.get());
+
+  delete raw;
+  EXPECT_FALSE(found);
+}
+
+TEST(SafePtr, PurgeSafePtrsDropsDeadEntriesWithoutCrashing)
+{
+  auto* raw = base::make_safe<Virtual>().get();
+  ASSERT_TRUE(base::findSafePtr(raw));
+
+  delete raw;
+
+  // The index still holds a (now-null) entry for `raw` until purged; the
+  // lookup itself is already false because the safe_ptr's storage was
+  // cleared by the destructor.
+  EXPECT_FALSE(base::findSafePtr(raw));
+
+  // Purging should be safe to call and must not resurrect the dead entry.
+  base::purgeSafePtrs();
+  EXPECT_FALSE(base::findSafePtr(raw));
+}
+
+TEST(SafePtr, SaveSafePtrOverwritesAStaleEntryAtAReusedAddress)
+{
+  // A make_safe()'d object can be deleted and the allocator can hand its
+  // exact address back out to a *new* make_safe() call before anyone runs
+  // purgeSafePtrs(). The stale (dead) index entry for that address must
+  // not shadow the new, live registration.
+  auto* first = base::make_safe<Virtual>().get();
+  ASSERT_TRUE(base::findSafePtr(first));
+  delete first;
+  ASSERT_FALSE(base::findSafePtr(first));
+
+  void* reused = nullptr;
+  for (int attempt = 0; attempt < 64 && !reused; ++attempt) {
+    auto* candidate = base::make_safe<Virtual>().get();
+    if (static_cast<void*>(candidate) == static_cast<void*>(first)) {
+      reused = candidate;
+    }
+    else {
+      delete candidate;
+    }
+  }
+
+  if (!reused) {
+    GTEST_SKIP() << "allocator never reused the freed address in 64 attempts";
+    return;
+  }
+
+  auto found = base::findSafePtr(reinterpret_cast<Virtual*>(reused));
+  ASSERT_TRUE(found);
+  EXPECT_EQ(reused, found.get());
+
+  delete reinterpret_cast<Virtual*>(reused);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/base/safe_ptr_tests.cpp
+++ b/test/base/safe_ptr_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/base/split_string_tests.cpp
+++ b/test/base/split_string_tests.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/split_string.h"
+#include "base/string.h"
 
 TEST(SplitString, Empty)
 {
@@ -45,6 +46,57 @@ TEST(SplitString, MultipleSeparators)
   EXPECT_EQ("Hello", result[0]);
   EXPECT_EQ("Wo", result[1]);
   EXPECT_EQ("ld", result[2]);
+}
+
+// base::split() (base/string.h) is a separate, newer helper: single-char
+// delimiter, returns the tokens directly instead of an out-parameter.
+
+TEST(Split, EmptyStringYieldsOneEmptyToken)
+{
+  auto result = base::split("", ',');
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("", result[0]);
+}
+
+TEST(Split, NoDelimiterPresentYieldsTheWholeString)
+{
+  auto result = base::split("HelloWorld", ',');
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("HelloWorld", result[0]);
+}
+
+TEST(Split, SplitsOnEveryOccurrence)
+{
+  auto result = base::split("a,b,c", ',');
+  ASSERT_EQ(3u, result.size());
+  EXPECT_EQ("a", result[0]);
+  EXPECT_EQ("b", result[1]);
+  EXPECT_EQ("c", result[2]);
+}
+
+TEST(Split, LeadingDelimiterKeepsAnEmptyFirstToken)
+{
+  auto result = base::split(",a", ',');
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("", result[0]);
+  EXPECT_EQ("a", result[1]);
+}
+
+TEST(Split, TrailingDelimiterKeepsAnEmptyLastToken)
+{
+  auto result = base::split("a,", ',');
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("a", result[0]);
+  EXPECT_EQ("", result[1]);
+}
+
+TEST(Split, ConsecutiveDelimitersKeepEmptyTokensBetweenThem)
+{
+  auto result = base::split("a,,b", ',');
+  ASSERT_EQ(3u, result.size());
+  EXPECT_EQ("a", result[0]);
+  EXPECT_EQ("", result[1]);
+  EXPECT_EQ("b", result[2]);
 }
 
 int main(int argc, char** argv)

--- a/test/base/with_handle_tests.cpp
+++ b/test/base/with_handle_tests.cpp
@@ -1,0 +1,140 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#include <gtest/gtest.h>
+
+#include "base/with_handle.h"
+
+namespace {
+
+bool g_fooDestroyed = false;
+
+struct Foo : public WithHandle<Foo> {
+  int value = 5;
+  ~Foo() { g_fooDestroyed = true; }
+};
+
+struct SubFoo : public Foo {
+  int extra = 9;
+};
+
+struct Bar : public WithHandle<Bar> {
+  int other = 1;
+};
+
+} // namespace
+
+TEST(WithHandle, ValidWhileOwnerAlive)
+{
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+
+  EXPECT_TRUE(h);
+  EXPECT_EQ(obj, h.get<Foo>());
+
+  delete obj;
+}
+
+TEST(WithHandle, ExpiresWhenOwnerDestroyed)
+{
+  g_fooDestroyed = false;
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+  ASSERT_TRUE(h);
+
+  delete obj;
+
+  EXPECT_TRUE(g_fooDestroyed);
+  EXPECT_FALSE(h);
+  EXPECT_EQ(nullptr, h.get<Foo>());
+}
+
+TEST(WithHandle, GetReturnsNullOnTypeMismatch)
+{
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+
+  // Bar was never involved in constructing this handle, so its type hash
+  // does not match Foo's - a cross-type get() must fail closed.
+  EXPECT_EQ(nullptr, h.get<Bar>());
+
+  delete obj;
+}
+
+TEST(WithHandle, GetWithDerivedCastsDownWhenTypeMatches)
+{
+  auto* obj = new SubFoo();
+  Handle h = obj->handle(); // constructed against Foo (the WithHandle<Foo> base)
+
+  SubFoo* back = h.get<Foo, SubFoo>();
+  ASSERT_NE(nullptr, back);
+  EXPECT_EQ(obj, back);
+  EXPECT_EQ(9, back->extra);
+
+  delete obj;
+}
+
+TEST(WithHandle, VoidGetBypassesTypeCheck)
+{
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+
+  void* raw = h.get<void>();
+  EXPECT_EQ(static_cast<void*>(obj), raw);
+
+  delete obj;
+}
+
+TEST(WithHandle, ResetInvalidatesTheHandle)
+{
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+  ASSERT_TRUE(h);
+
+  h.reset();
+
+  EXPECT_FALSE(h);
+  EXPECT_EQ(nullptr, h.get<Foo>());
+
+  delete obj;
+}
+
+TEST(WithHandle, DisposeDeletesTheUnderlyingObjectOnce)
+{
+  g_fooDestroyed = false;
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+
+  h.dispose();
+
+  EXPECT_TRUE(g_fooDestroyed);
+  EXPECT_FALSE(h);
+}
+
+TEST(WithHandle, DisposeOnAnAlreadyExpiredHandleIsANoop)
+{
+  auto* obj = new Foo();
+  Handle h = obj->handle();
+  delete obj;
+  ASSERT_FALSE(h);
+
+  // Must not double-free or crash.
+  h.dispose();
+  EXPECT_FALSE(h);
+}
+
+TEST(WithHandle, DefaultConstructedHandleIsInvalid)
+{
+  Handle h;
+  EXPECT_FALSE(h);
+  EXPECT_EQ(nullptr, h.get<Foo>());
+  h.dispose(); // no-op, must not crash
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/base/with_handle_tests.cpp
+++ b/test/base/with_handle_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.


### PR DESCRIPTION
Closes #173. Part of the test-coverage tracking issue #172.

## What
Unit tests for the base-layer primitives that file formats, commands, and script objects are built on:
- `base::safe_ptr` / `make_safe` / `findSafePtr` / `saveSafePtr` / `purgeSafePtrs`
- `Handle` / `WithHandle`
- The `Injectable<>` / `inject<>` dependency-injection container (`Regular`, `Singleton`, `Provides` policies, `setDefault`, `getAll`/`getAllWithFlag`)
- `base::split()`
- `base::verify_filename()`
- `base::range`
- The newer `base::fs` helpers: `list_files`, `get_canonical_path`, `get_font_paths`

## Bugs found and fixed along the way

Writing the `safe_ptr` tests surfaced two real defects in `src/base/safe_ptr.h` (currently unused elsewhere in the codebase, which is presumably why these went unnoticed). Both are fixed here with a regression test each:

1. **Null dereference through the templated `operator T()`.** Unlike the null-safe `operator bool()`, the generic `operator T()` conversion unconditionally dereferenced the internal storage. Any code path that ends up selecting this templated conversion instead of `operator bool()` - such as GoogleTest's `AssertionResult`, whose SFINAE-guarded constructors probe `std::is_convertible<..., AssertionResult>` while resolving an implicit bool conversion - segfaults on a null/expired `safe_ptr`. Confirmed with a minimal repro outside the project before touching the fix. Fixed by constraining the operator to scalar targets only (so it's no longer a viable implicit-conversion candidate for arbitrary class types) and making it null-safe like `operator bool()`.
2. **Stale registrations on address reuse.** `saveSafePtr()` used `unordered_map::emplace()`, which silently no-ops if the key already exists. Once an object is deleted, its heap address can be handed back out to a new `make_safe()`'d object before `purgeSafePtrs()` runs; `emplace()` then left the old, dead entry in place instead of registering the new, live object, so `findSafePtr()` on the reused address incorrectly returned `false`. Reproduced deterministically (forcing address reuse) before fixing. Fixed by switching to `insert_or_assign()`.

## Testing
- `ninja` (full build, `RelWithDebInfo`) - clean.
- `ctest` - 40/40 passing (36 pre-existing + 4 new suites: `safe_ptr_tests`, `with_handle_tests`, `injection_tests`, `range_tests`).
- Verified both bug fixes by reverting each in isolation and confirming the corresponding new test fails without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)