### PR TITLE
Add test coverage for doc/render drawing algorithms

### DIFF
--- a/src/doc/brush.cpp
+++ b/src/doc/brush.cpp
@@ -1,5 +1,6 @@
 // Aseprite Document Library
-// Copyright (c) 2001-2016 David Capello
+// Aseprite  | Copyright (C) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -304,8 +305,14 @@ void Brush::regenerate()
         else {
           int c = size/2;
           int r = m_size/2;
-	  int sa = r * sin(m_angle * (PI / 180.0f)) + 0.5;
-	  int ca = r * cos(m_angle * (PI / 180.0f)) + 0.5;
+          // Round to nearest, not truncate: adding 0.5 before an (int) cast
+          // only rounds correctly for non-negative values, since the cast
+          // truncates toward zero. sin()/cos() are negative for half of all
+          // angles, so the old `+ 0.5` idiom under-rounded those (e.g.
+          // sin(180°)=-1 gave -4 instead of -5 for r=5), making the brush
+          // asymmetric between mirror angles like 90°/180°/270°.
+	  int sa = std::lround(r * sin(m_angle * (PI / 180.0f)));
+	  int ca = std::lround(r * cos(m_angle * (PI / 180.0f)));
           int x1 = -ca - -sa;
           int y1 = -sa + -ca;
           int x2 =  ca - -sa;
@@ -329,8 +336,10 @@ void Brush::regenerate()
 
       case kLineBrushType: {
 	int r = m_size/2;
-	int sa = r * sin(m_angle * (PI / 180.0)) + 0.5;
-	int ca = r * cos(m_angle * (PI / 180.0)) + 0.5;
+        // See the note above kSquareBrushType: round to nearest (not
+        // truncate) so the line is symmetric across mirror angles.
+	int sa = std::lround(r * sin(m_angle * (PI / 180.0)));
+	int ca = std::lround(r * cos(m_angle * (PI / 180.0)));
 	int x1 = -ca + r;
 	int y1 = -sa + r;
 	int x2 =  ca + r;

--- a/test/doc/algo_tests.cpp
+++ b/test/doc/algo_tests.cpp
@@ -1,0 +1,129 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tests.h"
+
+#include "doc/algo.h"
+
+#include <vector>
+
+using namespace doc;
+
+namespace {
+
+std::vector<std::pair<int, int>> collectLine(int x1, int y1, int x2, int y2)
+{
+  std::vector<std::pair<int, int>> points;
+  algo_line(x1, y1, x2, y2, [&](int x, int y) { points.emplace_back(x, y); });
+  return points;
+}
+
+struct FloatPoint {
+  int x, y;
+  float f;
+};
+
+std::vector<FloatPoint> collectLineFloat(int x1, int y1, int x2, int y2)
+{
+  std::vector<FloatPoint> points;
+  algo_line_float(x1, y1, x2, y2, [&](int x, int y, float f) {
+    points.push_back({x, y, f});
+  });
+  return points;
+}
+
+} // namespace
+
+TEST(AlgoLineFloat, MatchesAlgoLinesPixelSetInEveryOctant)
+{
+  // One representative line per octant, both endpoints reachable from
+  // either direction, plus a couple of pure horizontal/vertical/diagonal
+  // cases.
+  const std::vector<std::tuple<int, int, int, int>> lines = {
+    {0, 0, 6, 2},   // shallow, +x +y
+    {0, 0, 2, 6},   // steep,   +x +y
+    {0, 0, 6, -2},  // shallow, +x -y
+    {0, 0, 2, -6},  // steep,   +x -y
+    {0, 0, -6, 2},  // shallow, -x +y
+    {0, 0, -2, 6},  // steep,   -x +y
+    {0, 0, -6, -2}, // shallow, -x -y
+    {0, 0, -2, -6}, // steep,   -x -y
+    {0, 0, 5, 0},   // horizontal
+    {0, 0, 0, 5},   // vertical
+    {0, 0, 4, 4},   // pure diagonal
+    {6, 2, 0, 0},   // reversed shallow
+  };
+
+  for (auto& [x1, y1, x2, y2] : lines) {
+    auto intPoints = collectLine(x1, y1, x2, y2);
+    auto floatPoints = collectLineFloat(x1, y1, x2, y2);
+
+    ASSERT_EQ(intPoints.size(), floatPoints.size())
+      << "line (" << x1 << "," << y1 << ")-(" << x2 << "," << y2 << ")";
+
+    for (std::size_t i = 0; i < intPoints.size(); ++i) {
+      EXPECT_EQ(intPoints[i].first, floatPoints[i].x)
+        << "point " << i << " of line (" << x1 << "," << y1 << ")-(" << x2 << "," << y2 << ")";
+      EXPECT_EQ(intPoints[i].second, floatPoints[i].y)
+        << "point " << i << " of line (" << x1 << "," << y1 << ")-(" << x2 << "," << y2 << ")";
+    }
+  }
+}
+
+TEST(AlgoLineFloat, FRunsMonotonicallyFromNearZeroToJustOverOne)
+{
+  auto points = collectLineFloat(0, 0, 8, 3);
+  ASSERT_GE(points.size(), 2u);
+
+  for (std::size_t i = 1; i < points.size(); ++i)
+    EXPECT_GT(points[i].f, points[i - 1].f) << "f must strictly increase at step " << i;
+
+  // First step is one unit of the parametric step (≈ 1/n); last step
+  // overshoots by that same one unit past the far endpoint (the loop counts
+  // n+1 points across n steps of size 1/n).
+  EXPECT_NEAR(points.front().f, points[1].f - points[0].f, 1e-4f);
+  EXPECT_GT(points.back().f, 1.0f);
+  EXPECT_LT(points.back().f, 1.0f + 2.0f * (points[1].f - points[0].f));
+}
+
+TEST(AlgoLineFloat, FIncreasesRegardlessOfWhichOctantOrDirection)
+{
+  const std::vector<std::tuple<int, int, int, int>> lines = {
+    {0, 0, 5, 0}, {5, 0, 0, 0},
+    {0, 0, 0, 5}, {0, 5, 0, 0},
+    {0, 0, -5, -5}, {-5, -5, 0, 0},
+    {0, 0, -1, -4}, {0, 0, 2, -5},
+  };
+  for (auto& [x1, y1, x2, y2] : lines) {
+    auto points = collectLineFloat(x1, y1, x2, y2);
+    for (std::size_t i = 1; i < points.size(); ++i) {
+      EXPECT_GT(points[i].f, points[i - 1].f)
+        << "line (" << x1 << "," << y1 << ")-(" << x2 << "," << y2 << ") step " << i;
+    }
+  }
+}
+
+TEST(AlgoLineFloat, ZeroLengthLineCallsBackExactlyOnce)
+{
+  auto points = collectLineFloat(3, 3, 3, 3);
+  ASSERT_EQ(1u, points.size());
+  EXPECT_EQ(3, points[0].x);
+  EXPECT_EQ(3, points[0].y);
+  EXPECT_FLOAT_EQ(0.0f, points[0].f);
+}
+
+TEST(AlgoLineFloat, TemplateOverloadForwardsToTheCallback)
+{
+  int calls = 0;
+  algo_line_float(0, 0, 3, 0, [&](int x, int y, float f) {
+    (void)x; (void)y; (void)f;
+    ++calls;
+  });
+  EXPECT_EQ(4, calls); // x = 0,1,2,3
+}

--- a/test/doc/algo_tests.cpp
+++ b/test/doc/algo_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/doc/brush_tests.cpp
+++ b/test/doc/brush_tests.cpp
@@ -1,0 +1,206 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tests.h"
+
+#include "doc/brush.h"
+#include "doc/image.h"
+
+#include <cmath>
+
+using namespace doc;
+
+namespace {
+
+// Counts set pixels in a brush's (always square) bitmap image.
+int countSetPixels(Brush& brush)
+{
+  Image* img = brush.image();
+  int count = 0;
+  for (int y = 0; y < img->height(); ++y)
+    for (int x = 0; x < img->width(); ++x)
+      if (img->getPixel(x, y) != 0)
+        ++count;
+  return count;
+}
+
+} // namespace
+
+TEST(Brush, DefaultIsAOnePixelCircle)
+{
+  Brush brush;
+  EXPECT_EQ(kCircleBrushType, brush.type());
+  EXPECT_EQ(1, brush.size());
+  EXPECT_EQ(0, brush.angle());
+  EXPECT_EQ(1, brush.image()->width());
+  EXPECT_EQ(1, brush.image()->height());
+  EXPECT_NE(0, brush.image()->getPixel(0, 0));
+}
+
+TEST(Brush, CircleIgnoresRotationEntirely)
+{
+  Brush flat(kCircleBrushType, 9, 0);
+  Brush rotated(kCircleBrushType, 9, 137);
+
+  ASSERT_EQ(flat.bounds(), rotated.bounds());
+  ASSERT_EQ(flat.image()->width(), rotated.image()->width());
+  ASSERT_EQ(flat.image()->height(), rotated.image()->height());
+
+  for (int y = 0; y < flat.image()->height(); ++y)
+    for (int x = 0; x < flat.image()->width(); ++x)
+      EXPECT_EQ(flat.image()->getPixel(x, y), rotated.image()->getPixel(x, y))
+        << "at (" << x << "," << y << ")";
+}
+
+TEST(Brush, SquareAtZeroAngleKeepsTheOriginalSizeAndIsFullyFilled)
+{
+  Brush brush(kSquareBrushType, 6, 0);
+
+  EXPECT_EQ(6, brush.image()->width());
+  EXPECT_EQ(6, brush.image()->height());
+  EXPECT_EQ(gfx::Rect(-3, -3, 6, 6), brush.bounds());
+  EXPECT_EQ(6 * 6, countSetPixels(brush));
+}
+
+TEST(Brush, RotatedSquareGrowsItsCanvasBySqrtTwoTimesSizePlusTwo)
+{
+  const int size = 8;
+  const int expectedCanvas = static_cast<int>(std::sqrt(2.0 * size * size)) + 2;
+
+  Brush brush(kSquareBrushType, size, 45);
+
+  EXPECT_EQ(expectedCanvas, brush.image()->width());
+  EXPECT_EQ(expectedCanvas, brush.image()->height());
+  EXPECT_EQ(gfx::Rect(-expectedCanvas / 2, -expectedCanvas / 2, expectedCanvas, expectedCanvas),
+            brush.bounds());
+  EXPECT_GT(countSetPixels(brush), 0);
+  // The rotated square must fit inside its enlarged canvas without filling
+  // it completely (that would mean no rotation actually happened).
+  EXPECT_LT(countSetPixels(brush), expectedCanvas * expectedCanvas);
+}
+
+TEST(Brush, RotatedSquareSizeTwoOrLessNeverEnlargesTheCanvas)
+{
+  // size <= 2 bypasses the rotation branch entirely regardless of angle.
+  Brush size1(kSquareBrushType, 1, 45);
+  Brush size2(kSquareBrushType, 2, 45);
+
+  EXPECT_EQ(1, size1.image()->width());
+  EXPECT_EQ(2, size2.image()->width());
+  EXPECT_GT(countSetPixels(size1), 0);
+  EXPECT_EQ(4, countSetPixels(size2)); // fully filled 2x2
+}
+
+TEST(Brush, RotatedSquareAt90And180DegreesIsSymmetric)
+{
+  // A square rotated by a multiple of 90 degrees looks the same as the
+  // unrotated square, just rasterized on the (still enlarged, since the
+  // code enlarges for any nonzero angle) canvas.
+  Brush at90(kSquareBrushType, 8, 90);
+  Brush at180(kSquareBrushType, 8, 180);
+  Brush at270(kSquareBrushType, 8, 270);
+
+  ASSERT_EQ(at90.image()->width(), at180.image()->width());
+  ASSERT_EQ(at90.image()->width(), at270.image()->width());
+
+  int size = at90.image()->width();
+  int count90 = countSetPixels(at90);
+  int count180 = countSetPixels(at180);
+  int count270 = countSetPixels(at270);
+
+  // All three should cover the same number of pixels (same shape, just
+  // rotated by a right angle each time).
+  EXPECT_EQ(count90, count180);
+  EXPECT_EQ(count90, count270);
+
+  // The 180-degree rotation must be point-symmetric around the image
+  // center: pixel (x,y) set iff pixel (size-1-x, size-1-y) is set.
+  Image* img = at180.image();
+  for (int y = 0; y < size; ++y) {
+    for (int x = 0; x < size; ++x) {
+      EXPECT_EQ(img->getPixel(x, y) != 0, img->getPixel(size - 1 - x, size - 1 - y) != 0)
+        << "at (" << x << "," << y << ")";
+    }
+  }
+}
+
+TEST(Brush, LineBrushDrawsThroughTheCenterAtTheGivenAngle)
+{
+  Brush horizontal(kLineBrushType, 8, 0);
+  Brush vertical(kLineBrushType, 8, 90);
+
+  ASSERT_EQ(horizontal.image()->width(), vertical.image()->width());
+  int size = horizontal.image()->width();
+  int center = size / 2;
+
+  // A 0-degree line brush is a horizontal stroke through the vertical
+  // center; a 90-degree one is a vertical stroke through the horizontal
+  // center. Each must have at least one set pixel on its central row/column
+  // and the two brushes must not draw identical bitmaps.
+  bool anyOnCenterRow = false;
+  for (int x = 0; x < size; ++x)
+    anyOnCenterRow |= (horizontal.image()->getPixel(x, center) != 0);
+  EXPECT_TRUE(anyOnCenterRow);
+
+  bool anyOnCenterColumn = false;
+  for (int y = 0; y < size; ++y)
+    anyOnCenterColumn |= (vertical.image()->getPixel(center, y) != 0);
+  EXPECT_TRUE(anyOnCenterColumn);
+
+  bool identical = true;
+  for (int y = 0; y < size && identical; ++y)
+    for (int x = 0; x < size; ++x)
+      if ((horizontal.image()->getPixel(x, y) != 0) != (vertical.image()->getPixel(x, y) != 0)) {
+        identical = false;
+        break;
+      }
+  EXPECT_FALSE(identical);
+}
+
+TEST(Brush, SetAngleTriggersRegeneration)
+{
+  Brush brush(kSquareBrushType, 8, 0);
+  int genBefore = brush.gen();
+  int widthBefore = brush.image()->width();
+
+  brush.setAngle(45);
+
+  EXPECT_NE(genBefore, brush.gen());
+  EXPECT_NE(widthBefore, brush.image()->width()); // canvas grows for the rotated square
+}
+
+TEST(Brush, SetSizeTriggersRegeneration)
+{
+  Brush brush(kCircleBrushType, 4, 0);
+  int genBefore = brush.gen();
+
+  brush.setSize(9);
+
+  EXPECT_NE(genBefore, brush.gen());
+  EXPECT_EQ(9, brush.image()->width());
+}
+
+TEST(Brush, CopyConstructorPreservesTypeSizeAngleAndBitmap)
+{
+  Brush original(kSquareBrushType, 8, 45);
+  Brush copy(original);
+
+  EXPECT_EQ(original.type(), copy.type());
+  EXPECT_EQ(original.size(), copy.size());
+  EXPECT_EQ(original.angle(), copy.angle());
+  EXPECT_EQ(original.bounds(), copy.bounds());
+
+  Image* a = original.image();
+  Image* b = copy.image();
+  ASSERT_EQ(a->width(), b->width());
+  ASSERT_EQ(a->height(), b->height());
+  for (int y = 0; y < a->height(); ++y)
+    for (int x = 0; x < a->width(); ++x)
+      EXPECT_EQ(a->getPixel(x, y), b->getPixel(x, y));
+}

--- a/test/doc/brush_tests.cpp
+++ b/test/doc/brush_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/doc/conversion_she_tests.cpp
+++ b/test/doc/conversion_she_tests.cpp
@@ -1,0 +1,237 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tests.h"
+
+#include "doc/conversion_she.h"
+#include "doc/image.h"
+#include "doc/palette.h"
+#include "gfx/color.h"
+#include "she/sdl2/sdl2_surface.h"
+
+#include <memory>
+
+using namespace doc;
+
+namespace {
+
+// SDL2Surface can be built directly, without a live she::System: its
+// (width, height, destroy) constructor just calls SDL_CreateRGBSurface with
+// masks that match doc::rgba's own byte layout (r/g/b/a at shift 0/8/16/24),
+// so the "fast path" in convert_image_to_surface (which requires the
+// surface's shifts to equal doc::rgba_*_shift) is exercised - same as what
+// she's own SDL2 backend hands out in the real app.
+std::unique_ptr<she::SDL2Surface> makeSurface(int w, int h)
+{
+  return std::make_unique<she::SDL2Surface>(w, h, she::SDL2Surface::DestroyHandle);
+}
+
+gfx::Color pixelAt(she::Surface* surface, int x, int y)
+{
+  she::SurfaceLock lock(surface);
+  return surface->getPixel(x, y);
+}
+
+} // namespace
+
+TEST(ConvertImageToSurface, RgbImageCopiesExactly)
+{
+  std::unique_ptr<Image> image(Image::create(IMAGE_RGB, 2, 2));
+  image->putPixel(0, 0, doc::rgba(10, 20, 30, 255));
+  image->putPixel(1, 0, doc::rgba(40, 50, 60, 128));
+  image->putPixel(0, 1, doc::rgba(70, 80, 90, 0));
+  image->putPixel(1, 1, doc::rgba(255, 0, 0, 255));
+
+  auto surface = makeSurface(2, 2);
+  convert_image_to_surface(image.get(), nullptr, surface.get(), 0, 0, 0, 0, 2, 2);
+
+  EXPECT_EQ(gfx::rgba(10, 20, 30, 255), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::rgba(40, 50, 60, 128), pixelAt(surface.get(), 1, 0));
+  EXPECT_EQ(gfx::rgba(70, 80, 90, 0), pixelAt(surface.get(), 0, 1));
+  EXPECT_EQ(gfx::rgba(255, 0, 0, 255), pixelAt(surface.get(), 1, 1));
+}
+
+TEST(ConvertImageToSurface, GrayscaleImageExpandsToRgba)
+{
+  std::unique_ptr<Image> image(Image::create(IMAGE_GRAYSCALE, 2, 1));
+  image->putPixel(0, 0, doc::graya(128, 255));
+  image->putPixel(1, 0, doc::graya(0, 64));
+
+  auto surface = makeSurface(2, 1);
+  convert_image_to_surface(image.get(), nullptr, surface.get(), 0, 0, 0, 0, 2, 1);
+
+  EXPECT_EQ(gfx::rgba(128, 128, 128, 255), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::rgba(0, 0, 0, 64), pixelAt(surface.get(), 1, 0));
+}
+
+TEST(ConvertImageToSurface, IndexedImageLooksUpThePalette)
+{
+  auto palette = Palette::create(4);
+  palette->setEntry(0, doc::rgba(0, 0, 0, 0));      // the "transparent" index
+  palette->setEntry(1, doc::rgba(255, 0, 0, 255));
+  palette->setEntry(2, doc::rgba(0, 255, 0, 255));
+  palette->setEntry(3, doc::rgba(0, 0, 255, 200));
+
+  std::unique_ptr<Image> image(Image::create(IMAGE_INDEXED, 4, 1));
+  image->putPixel(0, 0, 0);
+  image->putPixel(1, 0, 1);
+  image->putPixel(2, 0, 2);
+  image->putPixel(3, 0, 3);
+
+  auto surface = makeSurface(4, 1);
+  convert_image_to_surface(image.get(), palette.get(), surface.get(), 0, 0, 0, 0, 4, 1);
+
+  // Index 0 is only "transparent" in the sense that its palette entry says
+  // so (alpha 0) - convert_image_to_surface does a plain palette lookup,
+  // with no separate special-casing of any particular index.
+  EXPECT_EQ(gfx::rgba(0, 0, 0, 0), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::rgba(255, 0, 0, 255), pixelAt(surface.get(), 1, 0));
+  EXPECT_EQ(gfx::rgba(0, 255, 0, 255), pixelAt(surface.get(), 2, 0));
+  EXPECT_EQ(gfx::rgba(0, 0, 255, 200), pixelAt(surface.get(), 3, 0));
+}
+
+TEST(ConvertImageToSurface, BitmapImageLooksUpThePaletteByZeroOrOne)
+{
+  auto palette = Palette::create(2);
+  palette->setEntry(0, doc::rgba(0, 0, 0, 0));
+  palette->setEntry(1, doc::rgba(255, 255, 255, 255));
+
+  std::unique_ptr<Image> image(Image::create(IMAGE_BITMAP, 2, 1));
+  image->putPixel(0, 0, 0);
+  image->putPixel(1, 0, 1);
+
+  auto surface = makeSurface(2, 1);
+  convert_image_to_surface(image.get(), palette.get(), surface.get(), 0, 0, 0, 0, 2, 1);
+
+  EXPECT_EQ(gfx::rgba(0, 0, 0, 0), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::rgba(255, 255, 255, 255), pixelAt(surface.get(), 1, 0));
+}
+
+TEST(ConvertImageToSurface, PartialSourceRectOnlyCopiesThatRegion)
+{
+  // A 4x4 source image, but only its [1,1]-[3,3) sub-rect (2x2) is copied,
+  // landing at (5,5) on a larger surface. Everything else on the surface
+  // must be left at its cleared value.
+  std::unique_ptr<Image> image(Image::create(IMAGE_RGB, 4, 4));
+  for (int y = 0; y < 4; ++y)
+    for (int x = 0; x < 4; ++x)
+      image->putPixel(x, y, doc::rgba(x * 10, y * 10, 0, 255));
+
+  auto surface = makeSurface(10, 10);
+  surface->clear();
+
+  convert_image_to_surface(image.get(), nullptr, surface.get(),
+                            /*src*/ 1, 1, /*dst*/ 5, 5, /*w,h*/ 2, 2);
+
+  // The copied 2x2 block: source (1,1)-(2,2) -> dest (5,5)-(6,6).
+  EXPECT_EQ(gfx::rgba(10, 10, 0, 255), pixelAt(surface.get(), 5, 5));
+  EXPECT_EQ(gfx::rgba(20, 10, 0, 255), pixelAt(surface.get(), 6, 5));
+  EXPECT_EQ(gfx::rgba(10, 20, 0, 255), pixelAt(surface.get(), 5, 6));
+  EXPECT_EQ(gfx::rgba(20, 20, 0, 255), pixelAt(surface.get(), 6, 6));
+
+  // Untouched surface pixels remain cleared (all zero).
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 9, 9));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 4, 4));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 7, 7));
+}
+
+TEST(ConvertImageToSurface, ClipsToTheImageBoundsWhenTheRectOverhangs)
+{
+  // Requesting a 4x4 region from a 2x2 image: only the overlapping 2x2
+  // corner should actually be copied, at the requested destination offset.
+  std::unique_ptr<Image> image(Image::create(IMAGE_RGB, 2, 2));
+  image->putPixel(0, 0, doc::rgba(1, 2, 3, 255));
+  image->putPixel(1, 0, doc::rgba(4, 5, 6, 255));
+  image->putPixel(0, 1, doc::rgba(7, 8, 9, 255));
+  image->putPixel(1, 1, doc::rgba(10, 11, 12, 255));
+
+  auto surface = makeSurface(4, 4);
+  surface->clear();
+
+  convert_image_to_surface(image.get(), nullptr, surface.get(), 0, 0, 0, 0, 4, 4);
+
+  EXPECT_EQ(gfx::rgba(1, 2, 3, 255), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::rgba(4, 5, 6, 255), pixelAt(surface.get(), 1, 0));
+  EXPECT_EQ(gfx::rgba(7, 8, 9, 255), pixelAt(surface.get(), 0, 1));
+  EXPECT_EQ(gfx::rgba(10, 11, 12, 255), pixelAt(surface.get(), 1, 1));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 2, 2));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 3, 3));
+}
+
+TEST(ConvertImageToSurface, ClipsToTheSurfaceBoundsWhenTheDestinationOverhangs)
+{
+  std::unique_ptr<Image> image(Image::create(IMAGE_RGB, 3, 3));
+  for (int y = 0; y < 3; ++y)
+    for (int x = 0; x < 3; ++x)
+      image->putPixel(x, y, doc::rgba(x, y, 9, 255));
+
+  auto surface = makeSurface(2, 2);
+  surface->clear();
+
+  // Destination offset (1,1) with a 3x3 source on a 2x2 surface: only the
+  // single overlapping pixel at (1,1) can land anywhere.
+  convert_image_to_surface(image.get(), nullptr, surface.get(), 0, 0, 1, 1, 3, 3);
+
+  EXPECT_EQ(gfx::rgba(0, 0, 9, 255), pixelAt(surface.get(), 1, 1));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 0, 0));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 0, 1));
+  EXPECT_EQ(gfx::Color(0), pixelAt(surface.get(), 1, 0));
+}
+
+TEST(ConvertImageToSurface, MatchesANaivePerPixelReferenceAcrossAWholeRgbImage)
+{
+  const int w = 6, h = 5;
+  std::unique_ptr<Image> image(Image::create(IMAGE_RGB, w, h));
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      image->putPixel(x, y, doc::rgba(
+        (x * 37 + y * 11) & 0xff,
+        (x * 53 + y * 7) & 0xff,
+        (x * 13 + y * 29) & 0xff,
+        (x + y) % 2 == 0 ? 255 : 60));
+    }
+  }
+
+  auto surface = makeSurface(w, h);
+  convert_image_to_surface(image.get(), nullptr, surface.get(), 0, 0, 0, 0, w, h);
+
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      color_t src = image->getPixel(x, y);
+      gfx::Color expected = gfx::rgba(
+        doc::rgba_getr(src), doc::rgba_getg(src),
+        doc::rgba_getb(src), doc::rgba_geta(src));
+      EXPECT_EQ(expected, pixelAt(surface.get(), x, y)) << "at (" << x << "," << y << ")";
+    }
+  }
+}
+
+TEST(ConvertImageToSurface, MatchesANaivePerPixelReferenceForIndexedImages)
+{
+  auto palette = Palette::create(6);
+  for (int i = 0; i < 6; ++i)
+    palette->setEntry(i, doc::rgba(i * 40, 255 - i * 40, i * 10, i == 0 ? 0 : 255));
+
+  const int w = 6, h = 1;
+  std::unique_ptr<Image> image(Image::create(IMAGE_INDEXED, w, h));
+  for (int x = 0; x < w; ++x)
+    image->putPixel(x, 0, x);
+
+  auto surface = makeSurface(w, h);
+  convert_image_to_surface(image.get(), palette.get(), surface.get(), 0, 0, 0, 0, w, h);
+
+  for (int x = 0; x < w; ++x) {
+    color_t expectedColor = palette->getEntry(image->getPixel(x, 0));
+    gfx::Color expected = gfx::rgba(
+      doc::rgba_getr(expectedColor), doc::rgba_getg(expectedColor),
+      doc::rgba_getb(expectedColor), doc::rgba_geta(expectedColor));
+    EXPECT_EQ(expected, pixelAt(surface.get(), x, 0)) << "at index " << x;
+  }
+}

--- a/test/doc/conversion_she_tests.cpp
+++ b/test/doc/conversion_she_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/doc/polygon_tests.cpp
+++ b/test/doc/polygon_tests.cpp
@@ -1,0 +1,124 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "tests.h"
+
+#include "doc/algorithm/polygon.h"
+
+#include <vector>
+
+using namespace doc;
+
+namespace {
+
+struct Span { int y, x1, x2; };
+
+bool operator==(const Span& a, const Span& b)
+{
+  return a.y == b.y && a.x1 == b.x1 && a.x2 == b.x2;
+}
+
+std::vector<Span> fillPolygon(const std::vector<int>& xy)
+{
+  std::vector<Span> spans;
+  algorithm::polygon(
+    static_cast<int>(xy.size() / 2), xy.data(), 2, &spans,
+    [](int x1, int y, int x2, void* data) {
+      static_cast<std::vector<Span>*>(data)->push_back({y, x1, x2});
+    });
+  return spans;
+}
+
+} // namespace
+
+TEST(Polygon, RightTriangleScanlineSpans)
+{
+  // (0,0) - (4,0) - (0,4): a right triangle whose hypotenuse shrinks the
+  // span by one pixel per row.
+  auto spans = fillPolygon({0, 0, 4, 0, 0, 4});
+
+  ASSERT_EQ(5u, spans.size());
+  EXPECT_EQ((Span{0, 0, 4}), spans[0]);
+  EXPECT_EQ((Span{1, 0, 3}), spans[1]);
+  EXPECT_EQ((Span{2, 0, 2}), spans[2]);
+  EXPECT_EQ((Span{3, 0, 1}), spans[3]);
+  EXPECT_EQ((Span{4, 0, 0}), spans[4]);
+}
+
+TEST(Polygon, AxisAlignedSquareFillsEveryRowFully)
+{
+  auto spans = fillPolygon({0, 0, 4, 0, 4, 4, 0, 4});
+
+  ASSERT_EQ(5u, spans.size());
+  for (auto& s : spans)
+    EXPECT_EQ((Span{s.y, 0, 4}), s);
+}
+
+TEST(Polygon, HorizontalEdgesAreSkippedButStillFillCorrectly)
+{
+  // A single-row rectangle: top and bottom edges are horizontal (skipped
+  // outright), only the two vertical edges contribute intersections.
+  auto spans = fillPolygon({0, 0, 4, 0, 4, 1, 0, 1});
+
+  ASSERT_EQ(2u, spans.size());
+  EXPECT_EQ((Span{0, 0, 4}), spans[0]);
+  EXPECT_EQ((Span{1, 0, 4}), spans[1]);
+}
+
+TEST(Polygon, ConcaveUShapeProducesTwoSpansPerNotchedRow)
+{
+  // A "U": two legs (x in [0,1] and [3,4]) for y in [0,3], joined by a base
+  // for y in [4,5]. The notch must yield two separate spans, not one.
+  auto spans = fillPolygon({
+    0, 0, 1, 0, 1, 4, 3, 4, 3, 0, 4, 0, 4, 5, 0, 5
+  });
+
+  auto spansForRow = [&](int y) {
+    std::vector<Span> row;
+    for (auto& s : spans)
+      if (s.y == y)
+        row.push_back(s);
+    return row;
+  };
+
+  for (int y = 0; y <= 3; ++y) {
+    auto row = spansForRow(y);
+    ASSERT_EQ(2u, row.size()) << "row " << y;
+    EXPECT_EQ((Span{y, 0, 1}), row[0]);
+    EXPECT_EQ((Span{y, 3, 4}), row[1]);
+  }
+
+  for (int y = 4; y <= 5; ++y) {
+    auto row = spansForRow(y);
+    ASSERT_EQ(1u, row.size()) << "row " << y;
+    EXPECT_EQ((Span{y, 0, 4}), row[0]);
+  }
+}
+
+TEST(Polygon, EmptyPolygonProducesNoSpans)
+{
+  auto spans = fillPolygon({});
+  EXPECT_TRUE(spans.empty());
+}
+
+TEST(Polygon, ContainerOverloadMatchesThePointerOverload)
+{
+  struct Point { int x, y; };
+  std::vector<Point> triangle = {{0, 0}, {4, 0}, {0, 4}};
+
+  std::vector<Span> spans;
+  algorithm::polygon(triangle, [&](int x1, int y, int x2) {
+    spans.push_back({y, x1, x2});
+  });
+
+  auto expected = fillPolygon({0, 0, 4, 0, 0, 4});
+  ASSERT_EQ(expected.size(), spans.size());
+  for (std::size_t i = 0; i < expected.size(); ++i)
+    EXPECT_EQ(expected[i], spans[i]);
+}

--- a/test/doc/polygon_tests.cpp
+++ b/test/doc/polygon_tests.cpp
@@ -1,4 +1,4 @@
-// Besprited | Copyright (C) 2026 Veritaware
+// Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/test/render/render_tests.cpp
+++ b/test/render/render_tests.cpp
@@ -187,6 +187,105 @@ TEST(Render, CheckedBackground)
     1, 1, 2, 2,
     2, 2, 1, 1,
     2, 2, 1, 1);
+
+  // With bgZoom on, a checker tile scales together with the zoom factor:
+  // size(1,1) at 3x zoom covers the same ground as size(3,3) at 1x zoom.
+  render.setBgCheckedSize(gfx::Size(1, 1));
+  render.renderSprite(dst.get(),
+    doc->sprite(), frame_t(0),
+    gfx::Clip(dst->bounds()),
+    Zoom(3, 1));
+  EXPECT_4X4_PIXELS(dst.get(),
+    1, 1, 1, 2,
+    1, 1, 1, 2,
+    1, 1, 1, 2,
+    2, 2, 2, 1);
+
+  // With bgZoom off, the tile size is left alone regardless of zoom (as
+  // long as it isn't smaller than one zoomed pixel, which would otherwise
+  // clamp it back up) - so this is the same span-3-columns pattern as
+  // size(3,3) at 1x zoom above, not the fully-covered single tile you'd
+  // get if the size were scaled by 2x too.
+  render.setBgZoom(false);
+  render.setBgCheckedSize(gfx::Size(3, 3));
+  render.renderSprite(dst.get(),
+    doc->sprite(), frame_t(0),
+    gfx::Clip(dst->bounds()),
+    Zoom(2, 1));
+  EXPECT_4X4_PIXELS(dst.get(),
+    1, 1, 1, 2,
+    1, 1, 1, 2,
+    1, 1, 1, 2,
+    2, 2, 2, 1);
+
+  // ... while with bgZoom back on, that same size(3,3) tile at 2x zoom
+  // becomes a single 6x6 tile - larger than the whole 4x4 canvas, so it's
+  // one solid color.
+  render.setBgZoom(true);
+  render.renderSprite(dst.get(),
+    doc->sprite(), frame_t(0),
+    gfx::Clip(dst->bounds()),
+    Zoom(2, 1));
+  EXPECT_4X4_PIXELS(dst.get(),
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+    1, 1, 1, 1);
+}
+
+TEST(Render, CheckedBackgroundWithAnOddViewportOffset)
+{
+  Context ctx;
+  Document* doc = ctx.documents().add(4, 4, ColorMode::RGB);
+
+  std::unique_ptr<Image> dst(Image::create(IMAGE_RGB, 4, 4));
+
+  Render render;
+  render.setBgType(BgType::CHECKED);
+  render.setBgZoom(true);
+  render.setBgColor1(1);
+  render.setBgColor2(2);
+
+  // A source-space offset of one tile shifts the checker phase by one
+  // step, inverting the pattern relative to an unscrolled view - whether
+  // the offset is horizontal or vertical.
+  render.setBgCheckedSize(gfx::Size(1, 1));
+  clear_image(dst.get(), 0);
+  render.renderSprite(dst.get(), doc->sprite(), frame_t(0), gfx::Clip(0, 0, 1, 0, 4, 4));
+  EXPECT_4X4_PIXELS(dst.get(),
+    2, 1, 2, 1,
+    1, 2, 1, 2,
+    2, 1, 2, 1,
+    1, 2, 1, 2);
+
+  clear_image(dst.get(), 0);
+  render.renderSprite(dst.get(), doc->sprite(), frame_t(0), gfx::Clip(0, 0, 0, 1, 4, 4));
+  EXPECT_4X4_PIXELS(dst.get(),
+    2, 1, 2, 1,
+    1, 2, 1, 2,
+    2, 1, 2, 1,
+    1, 2, 1, 2);
+
+  // Offsetting by one tile in *both* directions flips the parity twice,
+  // landing back on the unscrolled pattern.
+  clear_image(dst.get(), 0);
+  render.renderSprite(dst.get(), doc->sprite(), frame_t(0), gfx::Clip(0, 0, 1, 1, 4, 4));
+  EXPECT_4X4_PIXELS(dst.get(),
+    1, 2, 1, 2,
+    2, 1, 2, 1,
+    1, 2, 1, 2,
+    2, 1, 2, 1);
+
+  // An offset that isn't a multiple of a (now 2px-wide) tile shifts each
+  // tile's visible split point rather than just flipping the parity.
+  render.setBgCheckedSize(gfx::Size(2, 2));
+  clear_image(dst.get(), 0);
+  render.renderSprite(dst.get(), doc->sprite(), frame_t(0), gfx::Clip(0, 0, 1, 0, 4, 4));
+  EXPECT_4X4_PIXELS(dst.get(),
+    1, 2, 2, 1,
+    1, 2, 2, 1,
+    2, 1, 1, 2,
+    2, 1, 1, 2);
 }
 
 TEST(Render, ZoomAndDstBounds)


### PR DESCRIPTION
Closes #175. Part of the test-coverage tracking issue #172.

## What
- `test/doc/algo_tests.cpp` - `doc::algo_line_float()` matches `algo_line`'s pixel set across every octant, `f` runs monotonically, zero-length line calls back exactly once, plus the templated overload.
- `test/doc/polygon_tests.cpp` - `doc::algorithm::polygon()`: right-triangle and axis-aligned scanline spans, horizontal-edge skipping, a proper concave "U" shape producing two spans per notched row, the empty-polygon case, and the container overload.
- `test/doc/brush_tests.cpp` - `Brush::regenerate()` for circle/square/line brushes: circle ignores rotation, unrotated square stays full-size, rotated square canvas grows to `floor(sqrt(2)*size)+2`, size ≤ 2 never enlarges, 90°/180°/270° symmetry, line brush direction, `setAngle`/`setSize` triggering regeneration, and copy-construction.
- `test/doc/conversion_she_tests.cpp` (new) - `convert_image_to_surface()` for RGB/grayscale/indexed(+palette, including a "transparent" index)/bitmap, a partial source rect, clipping against both the image and surface bounds, and two whole-image comparisons against a naive per-pixel reference. Builds a real `she::SDL2Surface` directly (no live `she::System` needed, since its constructor just calls `SDL_CreateRGBSurface` with masks matching `doc::rgba`'s own layout).
- Extended `test/render/render_tests.cpp`'s `Render.CheckedBackground` with non-default checker sizes interacting with zoom (`bgZoom` on/off, including the "clamp tile to at least one zoomed pixel" edge case), plus a new `Render.CheckedBackgroundWithAnOddViewportOffset` test covering horizontal/vertical/combined source-space scroll offsets and a non-tile-multiple offset.
- Sanity-checked the already-migrated `test/doc/blend_funcs_tests.cpp`: its 15 RGBA / 11 grayscale "special mode" lists already cover every blend mode with non-Normal behavior over a fully-transparent backdrop - `NORMAL` and the internal-only modes are correctly excluded (they're either the fallback target itself, or the HSL concepts don't apply to grayscale, where they're already aliased to Normal). No changes needed.

## Bug found and fixed along the way

Writing the `Brush` rotation tests surfaced a real rounding bug in `src/doc/brush.cpp`, fixed here with a regression test:

Both the rotated-square and rotated-line brush code computed their rotated offsets as `int sa = r * sin(angle) + 0.5;` (and the same for `cos`). Adding 0.5 before an `(int)` cast only rounds to nearest for non-negative values, since the cast truncates toward zero - `sin()`/`cos()` are negative for half of all angles, so those got under-rounded by one (e.g. `sin(180°) = -1` gave `sa = -4` instead of `-5` for `r = 5`). The practical effect: a rotated square or line brush was measurably asymmetric between mirror angles like 90°/180°/270°, when they mathematically should produce the same shape (81 vs. 49 set pixels for two rotations of the same square, in one concrete case). Fixed with `std::lround()`, which rounds correctly regardless of sign. Verified by reverting the fix locally and confirming the new symmetry test fails without it.

## Testing
- `ninja` (full build, `RelWithDebInfo`) - clean, including `besprited` itself.
- `ctest` - 48/48 passing (44 pre-existing + 4 new suites: `algo_tests`, `polygon_tests`, `brush_tests`, `conversion_she_tests`).
- Verified the brush fix by reverting it and confirming the corresponding test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)