### PR TITLE
Add test coverage for app core infrastructure

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -56,6 +56,8 @@ list(APPEND generated_files ${output_fn})
 
 # Directory where generated files by "gen" utility will stay.
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+set(APP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    CACHE INTERNAL "Extra include directory for app-lib's gen-generated headers (pref.xml.h, *.xml.h, skin.xml.h)")
 
 if(GEN_ONLY)
   add_library(app-lib ${generated_files})

--- a/src/app/ini_file.h
+++ b/src/app/ini_file.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite  | Copyright (C) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -54,8 +54,13 @@ namespace app {
 
   // Generic get/set_config_value functions
 
+  // Returns true when [section].name has a saved value, false when it's
+  // absent. (Previously inverted: it returned true for *absent* keys,
+  // silently flipping the meaning of every `!has_config_value(...)` call
+  // site - see main_window.cpp's DPI-default guards, which already assumed
+  // the correct "true means present" semantics implemented here.)
   inline bool has_config_value(const char* section, const char* name) {
-    return get_config_string(section, name, nullptr) == nullptr;
+    return get_config_string(section, name, nullptr) != nullptr;
   }
 
   inline const char* get_config_value(const char* section, const char* name, const char* value) {

--- a/src/app/task_manager.h
+++ b/src/app/task_manager.h
@@ -1,5 +1,5 @@
-// LibreSprite
-// Copyright (C) 2021 LibreSprite contributors
+// LibreSprite | Copyright (C) 2021 LibreSprite contributors
+// Besprited   | Copyright (C) 2026 Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -274,6 +274,12 @@ namespace app {
         });
       return pending.back();
     }
+
+    // Delivers whatever's currently ready right now, synchronously, on the
+    // calling thread. Exposed so tests can drive delayed()/addTask()
+    // callbacks deterministically without waiting on the real ui::Timer
+    // tick, which needs a running UI message loop.
+    void pump() { onTick(); }
 
     static TaskManager& instance() {
       if (!manager)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,15 @@ function(find_tests dir)
     set(entrypoint GTest::gtest)
   endif()
 
+  # Tests that link app-lib may reach for its gen-generated headers (e.g.
+  # pref.xml.h, pulled in by app/pref/preferences.h) - remember that before
+  # the WHOLE_ARCHIVE rewrite below removes "app-lib" from deps.
+  if("app-lib" IN_LIST deps)
+    set(_needs_app_lib TRUE)
+  else()
+    set(_needs_app_lib FALSE)
+  endif()
+
   # app-lib and script-lib both rely on static initializers (the FileFormat /
   # command injection registry, and the Engine / InternalScriptObject / qjs
   # EngineDelegate registrations respectively) that a normal static link
@@ -90,6 +99,15 @@ function(find_tests dir)
 
     if(NOT _linked_with_she EQUAL -1)
       target_compile_definitions(${testname} PRIVATE LINKED_WITH_SHE)
+    endif()
+
+    if(_needs_app_lib)
+      target_include_directories(${testname} PRIVATE ${APP_INCLUDE_DIR})
+      # app-lib is only reached through the WHOLE_ARCHIVE generator
+      # expression in ${prelibs} below, which alone doesn't force ninja to
+      # finish app-lib's own custom-command-generated headers before this
+      # target's sources (which may #include one of them) start compiling.
+      add_dependencies(${testname} app-lib)
     endif()
 
     target_link_libraries(${testname} PRIVATE

--- a/test/app/ini_file_tests.cpp
+++ b/test/app/ini_file_tests.cpp
@@ -35,6 +35,40 @@ TEST(IniFile, Basic)
   EXPECT_EQ(3, get_config_int("B", "b", 1));
 }
 
+TEST(IniFile, HasConfigValue)
+{
+  // Regression test: has_config_value() used to return true for an *absent*
+  // key (its body checked `== nullptr` instead of `!= nullptr`), silently
+  // inverting the meaning its own name promises and the meaning every call
+  // site (main_window.cpp's DPI-default guards) already assumed.
+  if (base::is_file("_has_config_value.ini"))
+    base::delete_file("_has_config_value.ini");
+
+  // set_config_file() re-loads into whatever CfgFile is already on top of
+  // the stack without clearing it first (real callers, e.g.
+  // Preferences::serializeDocPref(), always pair it with a preceding
+  // push_config_state() for exactly this reason - it hands out a brand new
+  // CfgFile to load into); push here too, so this test doesn't inherit
+  // leftover keys from another test's config file.
+  push_config_state();
+  set_config_file("_has_config_value.ini");
+
+  EXPECT_FALSE(has_config_value("A", "a"));
+
+  set_config_bool("A", "a", true);
+  EXPECT_TRUE(has_config_value("A", "a"));
+
+  // A saved empty string is still a *present* value.
+  set_config_string("A", "b", "");
+  EXPECT_TRUE(has_config_value("A", "b"));
+
+  // A different key/section than what was set must still read as absent.
+  EXPECT_FALSE(has_config_value("A", "c"));
+  EXPECT_FALSE(has_config_value("B", "a"));
+
+  pop_config_state();
+}
+
 TEST(IniFile, PushPop)
 {
   if (base::is_file("_a.ini")) base::delete_file("_a.ini");

--- a/test/app/resource_finder_tests.cpp
+++ b/test/app/resource_finder_tests.cpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/resource_finder.h"
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace app;
+
+namespace {
+
+// Saves an environment variable's value on construction and restores it
+// (or removes it, if it was unset) on destruction.
+class ScopedEnvVar {
+public:
+  ScopedEnvVar(const char* name, const char* value) : m_name(name) {
+    const char* prev = std::getenv(name);
+    if (prev)
+      m_prev = prev;
+    if (value)
+      setenv(name, value, 1);
+    else
+      unsetenv(name);
+  }
+
+  ~ScopedEnvVar() {
+    if (m_prev)
+      setenv(m_name.c_str(), m_prev->c_str(), 1);
+    else
+      unsetenv(m_name.c_str());
+  }
+
+private:
+  std::string m_name;
+  std::optional<std::string> m_prev;
+};
+
+std::vector<std::string> collectPaths(ResourceFinder& rf) {
+  std::vector<std::string> paths;
+  while (rf.next())
+    paths.push_back(rf.filename());
+  return paths;
+}
+
+} // namespace
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+
+TEST(ResourceFinder, IncludeUserDirUsesXdgConfigHomeWhenSet)
+{
+  ScopedEnvVar xdg("XDG_CONFIG_HOME", "/tmp/besprited-test-xdg");
+
+  ResourceFinder rf(false);
+  rf.includeUserDir("foo.ini");
+
+  auto paths = collectPaths(rf);
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ("/tmp/besprited-test-xdg/besprited/foo.ini", paths[0]);
+}
+
+TEST(ResourceFinder, IncludeUserDirFallsBackToHomeConfigWhenXdgUnset)
+{
+  ScopedEnvVar xdg("XDG_CONFIG_HOME", nullptr);
+  ScopedEnvVar home("HOME", "/tmp/besprited-test-home");
+
+  ResourceFinder rf(false);
+  rf.includeUserDir("foo.ini");
+
+  auto paths = collectPaths(rf);
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ("/tmp/besprited-test-home/.config/besprited/foo.ini", paths[0]);
+}
+
+TEST(ResourceFinder, IncludeUserDirTreatsAnEmptyXdgConfigHomeAsUnset)
+{
+  ScopedEnvVar xdg("XDG_CONFIG_HOME", "");
+  ScopedEnvVar home("HOME", "/tmp/besprited-test-home");
+
+  ResourceFinder rf(false);
+  rf.includeUserDir("foo.ini");
+
+  auto paths = collectPaths(rf);
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ("/tmp/besprited-test-home/.config/besprited/foo.ini", paths[0]);
+}
+
+TEST(ResourceFinder, IncludeDataDirCandidateOrderWithXdgSet)
+{
+  ScopedEnvVar xdg("XDG_CONFIG_HOME", "/tmp/besprited-test-xdg");
+
+  ResourceFinder rf(false);
+  rf.includeDataDir("skin.png");
+
+  auto paths = collectPaths(rf);
+  ASSERT_EQ(3u, paths.size());
+  // 1) $XDG_CONFIG_HOME/besprited/data/filename
+  EXPECT_EQ("/tmp/besprited-test-xdg/besprited/data/skin.png", paths[0]);
+  // 2) $BINDIR/data/filename
+  EXPECT_TRUE(paths[1].ends_with("data/skin.png")) << paths[1];
+  // 3) $BINDIR/../share/besprited/data/filename
+  EXPECT_TRUE(paths[2].ends_with("../share/besprited/data/skin.png")) << paths[2];
+}
+
+TEST(ResourceFinder, IncludeDataDirCandidateOrderWithoutXdg)
+{
+  ScopedEnvVar xdg("XDG_CONFIG_HOME", nullptr);
+  ScopedEnvVar home("HOME", "/tmp/besprited-test-home");
+
+  ResourceFinder rf(false);
+  rf.includeDataDir("skin.png");
+
+  auto paths = collectPaths(rf);
+  ASSERT_EQ(3u, paths.size());
+  // 1) $HOME/.config/besprited/data/filename
+  EXPECT_EQ("/tmp/besprited-test-home/.config/besprited/data/skin.png", paths[0]);
+  EXPECT_TRUE(paths[1].ends_with("data/skin.png")) << paths[1];
+  EXPECT_TRUE(paths[2].ends_with("../share/besprited/data/skin.png")) << paths[2];
+}
+
+#endif // !_WIN32 && !__APPLE__
+
+TEST(ResourceFinder, NextIteratesInAdditionOrderAndStopsAtTheEnd)
+{
+  ResourceFinder rf(false);
+  rf.addPath("a");
+  rf.addPath("b");
+  rf.addPath("c");
+
+  ASSERT_TRUE(rf.next());
+  EXPECT_EQ("a", rf.filename());
+  ASSERT_TRUE(rf.next());
+  EXPECT_EQ("b", rf.filename());
+  ASSERT_TRUE(rf.next());
+  EXPECT_EQ("c", rf.filename());
+  EXPECT_FALSE(rf.next());
+}
+
+TEST(ResourceFinder, DefaultFilenameFallsBackToTheFirstAddedPath)
+{
+  ResourceFinder rf(false);
+  rf.addPath("only-candidate");
+
+  EXPECT_EQ("only-candidate", rf.defaultFilename());
+}

--- a/test/app/symmetry_tests.cpp
+++ b/test/app/symmetry_tests.cpp
@@ -1,0 +1,309 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/pref/preferences.h" // for app::gen::SymmetryMode; pulls in pref.xml.h
+#include "app/tools/stroke.h"
+#include "app/tools/symmetry.h"
+#include "app/tools/tool_loop.h"
+#include "doc/brush.h"
+#include "gfx/region.h"
+#include "render/zoom.h"
+
+#include <algorithm>
+#include <set>
+
+using namespace app::tools;
+using namespace doc;
+
+namespace {
+
+// Symmetry::generateStrokes() only ever calls loop->getBrush() (to check
+// the brush bounds' width/height parity), so every other member of this
+// otherwise huge interface is an unused stub.
+class FakeToolLoop : public ToolLoop {
+public:
+  explicit FakeToolLoop(Brush brush) : m_brush(std::move(brush)) {}
+
+  void dispose() override {}
+  Tool* getTool() override { return nullptr; }
+  Brush* getBrush() override { return &m_brush; }
+  app::Document* getDocument() override { return nullptr; }
+  Sprite* sprite() override { return nullptr; }
+  Layer* getLayer() override { return nullptr; }
+  doc::frame_t getFrame() override { return 0; }
+  const Image* getSrcImage() override { return nullptr; }
+  const Image* getFloodFillSrcImage() override { return nullptr; }
+  Image* getDstImage() override { return nullptr; }
+  void validateSrcImage(const gfx::Region&) override {}
+  void validateDstImage(const gfx::Region&) override {}
+  void invalidateDstImage() override {}
+  void invalidateDstImage(const gfx::Region&) override {}
+  void copyValidDstToSrcImage(const gfx::Region&) override {}
+  RgbMap* getRgbMap() override { return nullptr; }
+  bool useMask() override { return false; }
+  Mask* getMask() override { return nullptr; }
+  void setMask(Mask*) override {}
+  gfx::Point getMaskOrigin() override { return {}; }
+  const render::Zoom& zoom() override { return m_zoom; }
+  Button getMouseButton() override { return Left; }
+  doc::color_t getFgColor() override { return 0; }
+  doc::color_t getBgColor() override { return 0; }
+  doc::color_t getPrimaryColor() override { return 0; }
+  void setPrimaryColor(doc::color_t) override {}
+  doc::color_t getSecondaryColor() override { return 0; }
+  void setSecondaryColor(doc::color_t) override {}
+  int getOpacity() override { return 255; }
+  int getTolerance() override { return 0; }
+  bool getContiguous() override { return true; }
+  ToolLoopModifiers getModifiers() override { return {}; }
+  filters::TiledMode getTiledMode() override { return {}; }
+  bool getGridVisible() override { return false; }
+  bool getSnapToGrid() override { return false; }
+  bool getStopAtGrid() override { return false; }
+  gfx::Rect getGridBounds() override { return {}; }
+  bool getFilled() override { return false; }
+  bool getPreviewFilled() override { return false; }
+  int getSprayWidth() override { return 0; }
+  int getSpraySpeed() override { return 0; }
+  gfx::Point getCelOrigin() override { return {}; }
+  void setSpeed(const gfx::Point&) override {}
+  gfx::Point getSpeed() override { return {}; }
+  Ink* getInk() override { return nullptr; }
+  Controller* getController() override { return nullptr; }
+  PointShape* getPointShape() override { return nullptr; }
+  Intertwine* getIntertwine() override { return nullptr; }
+  TracePolicy getTracePolicy() override { return {}; }
+  Symmetry* getSymmetry() override { return nullptr; }
+  const doc::Remap* getShadingRemap() override { return nullptr; }
+  void cancel() override {}
+  bool isCanceled() override { return false; }
+  gfx::Region& getDirtyArea() override { return m_dirtyArea; }
+  void updateDirtyArea() override {}
+  void updateStatusBar(const char*) override {}
+
+private:
+  Brush m_brush;
+  render::Zoom m_zoom{1, 1};
+  gfx::Region m_dirtyArea;
+};
+
+Stroke onePoint(int x, int y, float pressure) {
+  Stroke s;
+  s.addPoint({x, y, pressure});
+  return s;
+}
+
+} // namespace
+
+TEST(HorizontalSymmetry, MirrorsAroundTheAxisWithEvenBrushSize)
+{
+  Brush brush(doc::kCircleBrushType, 4, 0); // even size -> bounds.w % 2 == 0
+  FakeToolLoop loop{brush};
+
+  HorizontalSymmetry axis(10);
+  Strokes out;
+  axis.generateStrokes(onePoint(12, 5, 0.5f), out, &loop);
+
+  ASSERT_EQ(2u, out.size());
+  EXPECT_EQ(12, out[0][0].x);
+  EXPECT_EQ(5, out[0][0].y);
+  // Mirrors 12 around x=10 -> 8 (no +1 adjustment for an even brush).
+  EXPECT_EQ(8, out[1][0].x);
+  EXPECT_EQ(5, out[1][0].y);
+  EXPECT_FLOAT_EQ(0.5f, out[1][0].pressure);
+}
+
+TEST(HorizontalSymmetry, MirrorsAroundTheAxisWithOddBrushSizeAdjustsByOne)
+{
+  Brush brush(doc::kCircleBrushType, 5, 0); // odd size -> bounds.w % 2 == 1
+  FakeToolLoop loop{brush};
+
+  HorizontalSymmetry axis(10);
+  Strokes out;
+  axis.generateStrokes(onePoint(12, 5, 1.0f), out, &loop);
+
+  ASSERT_EQ(2u, out.size());
+  // With the +1 adjustment: 10 - (12 - 10 + 1) = 7.
+  EXPECT_EQ(7, out[1][0].x);
+  EXPECT_EQ(5, out[1][0].y);
+}
+
+TEST(VerticalSymmetry, MirrorsAroundTheAxisWithEvenAndOddBrushSize)
+{
+  Brush even(doc::kCircleBrushType, 4, 0);
+  Brush odd(doc::kCircleBrushType, 5, 0);
+
+  FakeToolLoop evenLoop{even};
+  FakeToolLoop oddLoop{odd};
+
+  VerticalSymmetry axis(10);
+
+  Strokes outEven;
+  axis.generateStrokes(onePoint(3, 12, 0.f), outEven, &evenLoop);
+  ASSERT_EQ(2u, outEven.size());
+  EXPECT_EQ(8, outEven[1][0].y);
+
+  Strokes outOdd;
+  axis.generateStrokes(onePoint(3, 12, 0.f), outOdd, &oddLoop);
+  ASSERT_EQ(2u, outOdd.size());
+  EXPECT_EQ(7, outOdd[1][0].y);
+}
+
+TEST(Diagonal45Symmetry, ReflectsAcrossTheSlopeMinusOneDiagonal)
+{
+  Brush brush;
+  FakeToolLoop loop{brush};
+  Diagonal45Symmetry axis(10, 10);
+
+  Strokes out;
+  // A point directly "east" of the center reflects to directly "north".
+  axis.generateStrokes(onePoint(14, 10, 0.f), out, &loop);
+
+  ASSERT_EQ(2u, out.size());
+  EXPECT_EQ(10, out[1][0].x);
+  EXPECT_EQ(6, out[1][0].y);
+}
+
+TEST(Diagonal135Symmetry, ReflectsAcrossTheSlopePlusOneDiagonal)
+{
+  Brush brush;
+  FakeToolLoop loop{brush};
+  Diagonal135Symmetry axis(10, 10);
+
+  Strokes out;
+  axis.generateStrokes(onePoint(14, 10, 0.f), out, &loop);
+
+  ASSERT_EQ(2u, out.size());
+  EXPECT_EQ(10, out[1][0].x);
+  EXPECT_EQ(14, out[1][0].y);
+}
+
+TEST(Rotational180Symmetry, RotatesAboutTheCenterWithBrushParityAdjustment)
+{
+  Brush odd(doc::kCircleBrushType, 5, 0);
+  FakeToolLoop loop{odd};
+  Rotational180Symmetry axis(10, 10);
+
+  Strokes out;
+  axis.generateStrokes(onePoint(14, 12, 0.f), out, &loop);
+
+  ASSERT_EQ(2u, out.size());
+  // 10 - (14-10+1) = 5 ; 10 - (12-10+1) = 7
+  EXPECT_EQ(5, out[1][0].x);
+  EXPECT_EQ(7, out[1][0].y);
+}
+
+TEST(Rotational90Symmetry, ProducesFourStrokesEachRotated90DegreesFromThePrevious)
+{
+  Brush brush;
+  FakeToolLoop loop{brush};
+  Rotational90Symmetry axis(10, 10);
+
+  Strokes out;
+  axis.generateStrokes(onePoint(14, 10, 0.75f), out, &loop);
+
+  ASSERT_EQ(4u, out.size());
+  EXPECT_EQ(14, out[0][0].x);
+  EXPECT_EQ(10, out[0][0].y);
+  // (dx,dy)=(4,0) -> (-0,4) -> point (10,14)
+  EXPECT_EQ(10, out[1][0].x);
+  EXPECT_EQ(14, out[1][0].y);
+  // -> (-4,0) -> point (6,10)
+  EXPECT_EQ(6, out[2][0].x);
+  EXPECT_EQ(10, out[2][0].y);
+  // -> (0,-4) -> point (10,6)
+  EXPECT_EQ(10, out[3][0].x);
+  EXPECT_EQ(6, out[3][0].y);
+
+  for (auto& stroke : out)
+    EXPECT_FLOAT_EQ(0.75f, stroke[0].pressure);
+
+  // A 4th application returns to the starting point (full turn).
+  int dx = out[3][0].x - 10, dy = out[3][0].y - 10;
+  EXPECT_EQ(14 - 10, -dy);
+  EXPECT_EQ(10 - 10, dx);
+}
+
+TEST(CompositeSymmetry, SingleAxisMatchesTheDedicatedSymmetryClass)
+{
+  Brush brush(doc::kCircleBrushType, 5, 0);
+  FakeToolLoop loop{brush};
+
+  CompositeSymmetry composite((int)app::gen::SymmetryMode::HORIZONTAL, 10, 10);
+  Strokes compositeOut;
+  composite.generateStrokes(onePoint(14, 3, 0.f), compositeOut, &loop);
+
+  HorizontalSymmetry dedicated(10);
+  Strokes dedicatedOut;
+  dedicated.generateStrokes(onePoint(14, 3, 0.f), dedicatedOut, &loop);
+
+  ASSERT_EQ(dedicatedOut.size(), compositeOut.size());
+  for (std::size_t i = 0; i < dedicatedOut.size(); ++i) {
+    EXPECT_EQ(dedicatedOut[i][0].x, compositeOut[i][0].x);
+    EXPECT_EQ(dedicatedOut[i][0].y, compositeOut[i][0].y);
+  }
+}
+
+TEST(CompositeSymmetry, CombiningTwoAxesYieldsFourStrokesWithNoDuplicates)
+{
+  Brush brush(doc::kCircleBrushType, 5, 0);
+  FakeToolLoop loop{brush};
+
+  int flags = (int)app::gen::SymmetryMode::HORIZONTAL | (int)app::gen::SymmetryMode::VERTICAL;
+  CompositeSymmetry composite(flags, 10, 10);
+
+  Strokes out;
+  composite.generateStrokes(onePoint(14, 3, 0.f), out, &loop);
+
+  ASSERT_EQ(4u, out.size());
+
+  std::set<std::pair<int, int>> uniquePoints;
+  for (auto& stroke : out)
+    uniquePoints.insert({stroke[0].x, stroke[0].y});
+  EXPECT_EQ(4u, uniquePoints.size());
+}
+
+TEST(CompositeSymmetry, CombiningAllFourAxesYieldsSixteenStrokesWithNoDuplicates)
+{
+  Brush brush(doc::kCircleBrushType, 5, 0);
+  FakeToolLoop loop{brush};
+
+  int flags = (int)app::gen::SymmetryMode::HORIZONTAL |
+              (int)app::gen::SymmetryMode::VERTICAL |
+              (int)app::gen::SymmetryMode::DIAGONAL_45 |
+              (int)app::gen::SymmetryMode::DIAGONAL_135;
+  CompositeSymmetry composite(flags, 10, 10);
+
+  // An asymmetric starting point (not on any axis) so all 16 combinations
+  // land on distinct pixels.
+  Strokes out;
+  composite.generateStrokes(onePoint(17, 4, 0.25f), out, &loop);
+
+  ASSERT_EQ(16u, out.size());
+
+  std::set<std::pair<int, int>> uniquePoints;
+  for (auto& stroke : out) {
+    uniquePoints.insert({stroke[0].x, stroke[0].y});
+    EXPECT_FLOAT_EQ(0.25f, stroke[0].pressure);
+  }
+  EXPECT_EQ(16u, uniquePoints.size());
+}
+
+TEST(CompositeSymmetry, NoFlagsLeavesOnlyTheOriginalStroke)
+{
+  Brush brush;
+  FakeToolLoop loop{brush};
+  CompositeSymmetry composite(0, 10, 10);
+
+  Strokes out;
+  composite.generateStrokes(onePoint(4, 4, 0.f), out, &loop);
+
+  ASSERT_EQ(1u, out.size());
+  EXPECT_EQ(4, out[0][0].x);
+  EXPECT_EQ(4, out[0][0].y);
+}

--- a/test/app/task_manager_tests.cpp
+++ b/test/app/task_manager_tests.cpp
@@ -1,0 +1,226 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+// TaskManager's constructor builds a ui::Timer, which asserts a live
+// ui::Manager exists (ui::Timer's owner defaults to Manager::getDefault()).
+#define TEST_GUI
+#include "tests.h"
+
+#include "app/task_manager.h"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace app;
+
+namespace {
+
+// Repeatedly pumps the TaskManager and sleeps briefly until `pred()` is
+// true or `timeout` elapses. Needed for anything that runs on one of
+// TaskManager's real background worker threads (addTask()), which
+// delayed() alone doesn't need.
+template<typename Pred>
+bool waitUntil(Pred&& pred, std::chrono::milliseconds timeout = std::chrono::seconds(3))
+{
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  do {
+    TaskManager::instance().pump();
+    if (pred())
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  } while (std::chrono::steady_clock::now() < deadline);
+  return pred();
+}
+
+class TaskManagerTest : public ::testing::Test {
+protected:
+  void TearDown() override {
+    // Each test gets a fresh TaskManager (and fresh background threads),
+    // so state from one test can't leak into the next.
+    TaskManager::cleanup();
+  }
+};
+
+} // namespace
+
+TEST_F(TaskManagerTest, DelayedCallbacksRunOnPumpInFifoOrder)
+{
+  std::vector<int> order;
+
+  TaskManager::instance().delayed([&] { order.push_back(1); });
+  TaskManager::instance().delayed([&] { order.push_back(2); });
+  TaskManager::instance().delayed([&] { order.push_back(3); });
+
+  EXPECT_TRUE(order.empty()); // nothing runs until pump()
+
+  TaskManager::instance().pump();
+
+  ASSERT_EQ(3u, order.size());
+  EXPECT_EQ(1, order[0]);
+  EXPECT_EQ(2, order[1]);
+  EXPECT_EQ(3, order[2]);
+}
+
+TEST_F(TaskManagerTest, DelayedCallbacksQueuedDuringAPumpWaitForTheNextOne)
+{
+  std::vector<int> order;
+
+  TaskManager::instance().delayed([&] {
+    order.push_back(1);
+    // Queuing another delayed task from inside a callback must not run it
+    // within this same pump() - see the maxTasks snapshot in onTick().
+    TaskManager::instance().delayed([&] { order.push_back(2); });
+  });
+
+  TaskManager::instance().pump();
+  ASSERT_EQ(1u, order.size());
+  EXPECT_EQ(1, order[0]);
+
+  TaskManager::instance().pump();
+  ASSERT_EQ(2u, order.size());
+  EXPECT_EQ(2, order[1]);
+}
+
+TEST_F(TaskManagerTest, AddTaskResultsAreDeliveredInProductionOrder)
+{
+  // Regression test for 0d75475c9: a single recurring task that produces
+  // several results over multiple invocations must have them delivered to
+  // the consumer in the order they were produced, not reversed.
+  std::mutex mutex;
+  std::vector<int> received;
+  std::atomic<int> nextValue{0};
+
+  TaskManager::instance().addTask<int>(
+    [&](std::atomic_bool& isAlive) -> int {
+      int v = nextValue.fetch_add(1);
+      if (v >= 4)
+        isAlive = false;
+      return v;
+    },
+    [&](int&& v) {
+      std::lock_guard<std::mutex> guard(mutex);
+      received.push_back(v);
+    });
+
+  ASSERT_TRUE(waitUntil([&] {
+    std::lock_guard<std::mutex> guard(mutex);
+    return received.size() >= 5;
+  }));
+
+  std::lock_guard<std::mutex> guard(mutex);
+  ASSERT_EQ(5u, received.size());
+  for (int i = 0; i < 5; ++i)
+    EXPECT_EQ(i, received[i]);
+}
+
+TEST_F(TaskManagerTest, TaskHandleAbortFlipsIsAliveAndStopsFurtherWork)
+{
+  std::atomic<int> invocations{0};
+
+  TaskHandle handle = TaskManager::instance().addTask<int>(
+    [&](std::atomic_bool&) -> int {
+      return invocations.fetch_add(1);
+    },
+    [&](int&&) {});
+
+  // Let it run at least once so we know the worker thread picked it up.
+  ASSERT_TRUE(waitUntil([&] { return invocations.load() > 0; }));
+
+  handle.abort();
+
+  int countAtAbort = invocations.load();
+  // Give it a moment to (not) keep running.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  TaskManager::instance().pump();
+
+  EXPECT_LE(invocations.load(), countAtAbort + 1); // at most one in-flight iteration finishes
+  EXPECT_TRUE(waitUntil([&] { return handle.done(); }));
+}
+
+TEST_F(TaskManagerTest, TaskMonitorAbortsOnScopeExit)
+{
+  std::atomic_bool aliveFlagSeen{true};
+  std::atomic<int> invocations{0};
+
+  {
+    TaskMonitor monitor;
+    monitor = TaskManager::instance().addTask<int>(
+      [&](std::atomic_bool& isAlive) -> int {
+        invocations.fetch_add(1);
+        aliveFlagSeen = (bool)isAlive;
+        return 0;
+      },
+      [&](int&&) {});
+
+    ASSERT_TRUE(waitUntil([&] { return invocations.load() > 0; }));
+  } // monitor destroyed here -> aborts the task
+
+  int countAtDestruction = invocations.load();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  TaskManager::instance().pump();
+
+  EXPECT_LE(invocations.load(), countAtDestruction + 1);
+}
+
+TEST_F(TaskManagerTest, AThrowingWorkerMarksTheTaskDone)
+{
+  TaskHandle handle = TaskManager::instance().addTask<int>(
+    [](std::atomic_bool&) -> int {
+      throw std::runtime_error("boom");
+    },
+    [](int&&) {});
+
+  EXPECT_TRUE(waitUntil([&] { return handle.done(); }));
+}
+
+TEST_F(TaskManagerTest, SingleShotAddTaskOverloadRunsOnceAndCallsTheAborterOnAbort)
+{
+  std::atomic<int> invocations{0};
+  std::atomic_bool aborterCalled{false};
+
+  TaskHandle handle = TaskManager::instance().addTask<int>(
+    [&]() -> int {
+      invocations.fetch_add(1);
+      return 42;
+    },
+    [](int&&) {},
+    [&] { aborterCalled = true; });
+
+  ASSERT_TRUE(waitUntil([&] { return handle.done(); }));
+  EXPECT_EQ(1, invocations.load());
+
+  // Aborting an already-finished task still runs the aborter (it doesn't
+  // check isDone), but must not crash or re-run the worker.
+  handle.abort();
+  EXPECT_TRUE(aborterCalled.load());
+  EXPECT_EQ(1, invocations.load());
+}
+
+TEST_F(TaskManagerTest, CleanupJoinsThreadsAndInstanceRecreatesAFreshManager)
+{
+  std::atomic<int> invocations{0};
+  TaskManager::instance().addTask<int>(
+    [&](std::atomic_bool& isAlive) -> int {
+      invocations.fetch_add(1);
+      isAlive = false;
+      return 0;
+    },
+    [](int&&) {});
+
+  ASSERT_TRUE(waitUntil([&] { return invocations.load() > 0; }));
+
+  // cleanup() must return only once every worker thread has been joined.
+  TaskManager::cleanup();
+
+  // A fresh instance() must work normally afterwards.
+  std::vector<int> order;
+  TaskManager::instance().delayed([&] { order.push_back(1); });
+  TaskManager::instance().pump();
+  ASSERT_EQ(1u, order.size());
+}


### PR DESCRIPTION
Closes #176. Part of the test-coverage tracking issue #172.

## What
- `test/app/task_manager_tests.cpp` - `TaskManager`/`TaskHandle`/`TaskMonitor`: `delayed()` FIFO ordering, `addTask()` result delivery order, `TaskHandle::abort()`, `TaskMonitor` scope-exit abort, a throwing worker marking the task done, the single-shot 3-arg `addTask` overload, and `cleanup()` joining threads then handing back a working fresh instance.
- `test/app/symmetry_tests.cpp` - all six `app::tools::*Symmetry` classes: Horizontal/Vertical brush-size parity adjustment, the two diagonal reflections, `Rotational180`'s parity adjustment, `Rotational90`'s 4-stroke cycle, and `CompositeSymmetry` (matches the dedicated class for a single axis, 4 strokes with no duplicates for two axes, 16 for all four).
- `test/app/resource_finder_tests.cpp` - `ResourceFinder::includeUserDir()`/`includeDataDir()`'s `XDG_CONFIG_HOME` handling (set, unset, empty-string-treated-as-unset) and candidate path ordering, plus basic `next()`/`defaultFilename()` coverage.
- Added `TaskManager::pump()` (called for in the issue): runs `onTick()` synchronously so tests can drive `delayed()`/`addTask()` callbacks deterministically instead of waiting on the real `ui::Timer` tick, which needs a running UI message loop.

`Symmetry::generateStrokes()`'s only interaction with `ToolLoop` is `getBrush()`, but the interface has 53 pure virtuals - `test/app/symmetry_tests.cpp` includes a minimal `FakeToolLoop` stub implementing all of them trivially.

## Bug found and fixed along the way

**`app::has_config_value()`** (`src/app/ini_file.h`) returned `true` for an *absent* key - its body checked `get_config_string(...) == nullptr` instead of `!= nullptr`, inverting the meaning both its own name and its three call sites in `main_window.cpp`'s DPI-default guards already assumed (they negate the result, expecting `true` to mean "present"). Fixing the function's body alone corrects the end-to-end behavior at all three call sites - they don't need editing, since they were already written assuming the correct semantics. Verified by reverting the fix and confirming the new regression test fails.

Separately, writing the "`addTask` results delivered in submission order" test (the regression target named in the issue, for commit `0d75475c9`) doubled as a live check that the historical fix is still in place: reverting `task->data`'s `front()`/`pop_front()` reads back to `back()`/`pop_back()` reproduces the old reversed-delivery bug and fails the test (`4,3,2,1,0` instead of `0,1,2,3,4`) - confirming the test actually exercises that code path, not just passing vacuously.

## Build system

`symmetry_tests.cpp` needs `app::gen::SymmetryMode`, which lives in a `gen`-generated header (`pref.xml.h`, reached via `app/pref/preferences.h`). This exposed two gaps in `test/CMakeLists.txt`:
- No test target had that generated header's directory on its include path (fixed by exporting `APP_INCLUDE_DIR` from `src/app/CMakeLists.txt`, mirroring the existing `BASE_INCLUDE_DIR`).
- Even with the include path fixed, nothing forced ninja to finish generating `app-lib`'s headers before a dependent test target's own sources started compiling - `app-lib` is only reached through a `WHOLE_ARCHIVE` link generator-expression, which doesn't impose that ordering. Fixed with an explicit `add_dependencies(<test>, app-lib)`. Verified with a from-scratch `rm -rf build` + full-parallelism build.

## Testing
- `ninja` (full build, `RelWithDebInfo`) - clean, including `besprited` itself.
- `ctest` - 51/51 passing (48 pre-existing + 3 new suites: `resource_finder_tests`, `symmetry_tests`, `task_manager_tests`; `ini_file_tests` extended in place).
- `task_manager_tests` run 4x in a row with no flakiness (~1s each).
- Verified both bugs by reverting each fix in isolation and confirming the corresponding test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)