### PR TITLE
Cover ui NumberEntry, text math expressions, MessageType

### DIFF
--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -144,12 +144,17 @@ void Widget::initTheme()
   onInitTheme(ev);
 }
 
+void Widget::onEvalError(const std::string& message) const
+{
+  ui::Alert::show("Error evaluating expression  <<%s||&OK", message.c_str());
+}
+
 int Widget::textInt() const
 {
   auto val = evalmath::eval(m_text);
   if(!val)
   {
-    ui::Alert::show("Error evaluating expression  <<%s||&OK", val.error().c_str());
+    onEvalError(val.error());
     return 1;
   }
 
@@ -161,7 +166,7 @@ double Widget::textDouble() const
   auto val = evalmath::eval(m_text);
   if(!val)
   {
-    ui::Alert::show("Error evaluating expression  <<%s||&OK", val.error().c_str());
+    onEvalError(val.error());
     return 1.0;
   }
   return std::round(val.value() * 1000.0) / 1000.0;

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -1,6 +1,6 @@
-// Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C)      2021  LibreSprite contributors
-// Besprited   | Copyright (C)      2026  Veritaware
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// LibreSprite | Copyright (C) 2021      LibreSprite contributors
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -1,5 +1,6 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C)      2021  LibreSprite contributors
+// Besprited   | Copyright (C)      2026  Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -393,6 +394,12 @@ namespace ui {
     virtual void onDeselect();
     virtual void onSetText();
     virtual void onSetBgColor();
+
+    // Called by textInt()/textDouble() when text() can't be parsed as a
+    // math expression. Default implementation blocks on a ui::Alert, which
+    // requires a live, message-pumping ui::Manager - override this (e.g. in
+    // a headless test) to observe/record the error without it.
+    virtual void onEvalError(const std::string& message) const;
 
   private:
     void removeChild(WidgetsList::iterator& it);

--- a/test/app/crash/read_document_tests.cpp
+++ b/test/app/crash/read_document_tests.cpp
@@ -11,9 +11,27 @@
 #include "app/crash/write_document.h"
 #include "app/document.h"
 #include "base/fs.h"
+#include "base/path.h"
 #include "doc/doc.h"
 
 using namespace app;
+
+namespace {
+
+// crash::write_document() populates the directory with several files
+// (cel-*, celdata-*, doc-*, img-*, lay-*, pal-*, spr-*) - base::remove_directory()
+// only removes an empty directory, so a fixture dir left over from a
+// previous write needs its contents cleared out first.
+void removeDirRecursive(const std::string& dir)
+{
+  if (!base::is_directory(dir))
+    return;
+  for (const auto& entry : base::list_files(dir))
+    base::delete_file(base::join_path(dir, entry));
+  base::remove_directory(dir);
+}
+
+} // namespace
 
 TEST(ReadDocumentInfo, NonSquareCanvasWidthAndHeightAreNotSwapped)
 {
@@ -29,8 +47,7 @@ TEST(ReadDocumentInfo, NonSquareCanvasWidthAndHeightAreNotSwapped)
   doc->setFilename("read_document_info_test.ase");
 
   const std::string dir = "read_document_info_test_dir";
-  if (base::is_directory(dir))
-    base::remove_directory(dir);
+  removeDirRecursive(dir);
   base::make_all_directories(dir);
 
   crash::write_document(dir, static_cast<app::Document*>(doc));
@@ -42,6 +59,7 @@ TEST(ReadDocumentInfo, NonSquareCanvasWidthAndHeightAreNotSwapped)
 
   doc->close();
   delete doc;
+  removeDirRecursive(dir);
 }
 
 TEST(ReadDocumentInfo, SquareCanvasStillRoundTripsCorrectly)
@@ -56,8 +74,7 @@ TEST(ReadDocumentInfo, SquareCanvasStillRoundTripsCorrectly)
   doc->setFilename("read_document_info_square_test.ase");
 
   const std::string dir = "read_document_info_square_test_dir";
-  if (base::is_directory(dir))
-    base::remove_directory(dir);
+  removeDirRecursive(dir);
   base::make_all_directories(dir);
 
   crash::write_document(dir, static_cast<app::Document*>(doc));
@@ -69,15 +86,17 @@ TEST(ReadDocumentInfo, SquareCanvasStillRoundTripsCorrectly)
 
   doc->close();
   delete doc;
+  removeDirRecursive(dir);
 }
 
 TEST(ReadDocumentInfo, ReturnsFalseForADirectoryWithNoBackup)
 {
   const std::string dir = "read_document_info_empty_test_dir";
-  if (base::is_directory(dir))
-    base::remove_directory(dir);
+  removeDirRecursive(dir);
   base::make_all_directories(dir);
 
   crash::DocumentInfo info;
   EXPECT_FALSE(crash::read_document_info(dir, info));
+
+  removeDirRecursive(dir);
 }

--- a/test/ui/message_type_tests.cpp
+++ b/test/ui/message_type_tests.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "ui/message_type.h"
+
+using namespace ui;
+
+TEST(MessageType, EveryRegisteredValueHasANonEmptyName)
+{
+  const MessageType types[] = {
+    kOpenMessage,          kCloseMessage,      kCloseDisplayMessage,
+    kResizeDisplayMessage, kPaintMessage,      kTimerMessage,
+    kDropFilesMessage,     kWinMoveMessage,    kKeyDownMessage,
+    kKeyUpMessage,         kFocusEnterMessage, kFocusLeaveMessage,
+    kMouseDownMessage,     kMouseUpMessage,    kDoubleClickMessage,
+    kMouseEnterMessage,    kMouseLeaveMessage, kMouseMoveMessage,
+    kSetCursorMessage,     kMouseWheelMessage, kTouchMagnifyMessage,
+  };
+
+  for (MessageType type : types)
+    EXPECT_STRNE("", to_string(type)) << "type index " << int(type);
+}
+
+TEST(MessageType, ValuesAtOrPastFirstRegisteredReturnAnEmptyString)
+{
+  EXPECT_STREQ("", to_string(kFirstRegisteredMessage));
+  EXPECT_STREQ("", to_string(static_cast<MessageType>(kFirstRegisteredMessage + 1)));
+  EXPECT_STREQ("", to_string(kLastRegisteredMessage));
+}

--- a/test/ui/number_entry_tests.cpp
+++ b/test/ui/number_entry_tests.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#define TEST_GUI
+#include "tests.h"
+
+#include "ui/message.h"
+#include "ui/number_entry.h"
+
+#include <climits>
+
+using namespace ui;
+
+namespace {
+
+// NumberEntry only validates/clamps on kFocusLeaveMessage - simulate losing
+// focus without needing a live Manager to actually move focus around.
+void loseFocus(NumberEntry& entry)
+{
+  Message msg(kFocusLeaveMessage);
+  entry.sendMessage(&msg);
+}
+
+} // namespace
+
+TEST(NumberEntry, SetValueClampsToMinMax)
+{
+  NumberEntry entry(0, 10);
+
+  entry.setValue(5);
+  EXPECT_EQ(5, entry.getValue());
+
+  entry.setValue(-3);
+  EXPECT_EQ(0, entry.getValue());
+
+  entry.setValue(20);
+  EXPECT_EQ(10, entry.getValue());
+}
+
+TEST(NumberEntry, FocusLeaveEvaluatesAMathExpression)
+{
+  NumberEntry entry(0, 100);
+
+  entry.setText("2*8");
+  loseFocus(entry);
+  EXPECT_EQ(16, entry.getValue());
+}
+
+TEST(NumberEntry, FocusLeaveRoundsANonIntegerResult)
+{
+  NumberEntry entry(0, 100);
+
+  entry.setText("7/2");
+  loseFocus(entry);
+  EXPECT_EQ(4, entry.getValue()); // 3.5 rounds to 4 (std::lround)
+}
+
+TEST(NumberEntry, FocusLeaveRevertsToTheLastValidValueOnUnparseableText)
+{
+  NumberEntry entry(0, 100);
+
+  entry.setValue(42);
+  entry.setText("abc");
+  loseFocus(entry);
+
+  EXPECT_EQ(42, entry.getValue());
+  EXPECT_EQ("42", entry.text());
+}
+
+TEST(NumberEntry, FocusLeaveClampsAnEvaluatedResultToMinMax)
+{
+  NumberEntry entry(0, 10);
+
+  entry.setText("999");
+  loseFocus(entry);
+  EXPECT_EQ(10, entry.getValue());
+
+  entry.setText("-999");
+  loseFocus(entry);
+  EXPECT_EQ(0, entry.getValue());
+}
+
+TEST(NumberEntry, FocusLeaveSaturatesRatherThanOverflowsOnAResultOutsideIntRange)
+{
+  // Distinct from the min/max clamp above: onProcessMessage() first clamps
+  // the evaluated (long) result into [INT_MIN, INT_MAX] before narrowing it
+  // to int, specifically to avoid signed-overflow UB on the narrowing cast.
+  // Give the entry an [INT_MIN, INT_MAX] range so that clamp is the only
+  // one in play.
+  NumberEntry entry(INT_MIN, INT_MAX);
+
+  entry.setText("99999999999"); // ~1e11, well past INT_MAX
+  loseFocus(entry);
+  EXPECT_EQ(INT_MAX, entry.getValue());
+
+  entry.setText("-99999999999");
+  loseFocus(entry);
+  EXPECT_EQ(INT_MIN, entry.getValue());
+}
+
+TEST(NumberEntry, SetMinAndSetMaxChangeTheClampRangeForFutureValues)
+{
+  NumberEntry entry(0, 10);
+
+  entry.setMin(5);
+  entry.setMax(8);
+  EXPECT_EQ(5, entry.min());
+  EXPECT_EQ(8, entry.max());
+
+  entry.setValue(0);
+  EXPECT_EQ(5, entry.getValue());
+
+  entry.setValue(100);
+  EXPECT_EQ(8, entry.getValue());
+}

--- a/test/ui/widget_text_math_tests.cpp
+++ b/test/ui/widget_text_math_tests.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#define TEST_GUI
+#include "tests.h"
+
+#include "ui/widget.h"
+
+#include <climits>
+#include <string>
+
+using namespace ui;
+
+namespace {
+
+// Widget::textInt()/textDouble() report a parse failure through the
+// overridable onEvalError() hook - the default implementation blocks on a
+// ui::Alert, which needs a live, message-pumping ui::Manager, so tests
+// override it instead to record the failure headlessly.
+class RecordingWidget : public Widget {
+public:
+  mutable int errorCount = 0;
+  mutable std::string lastError;
+
+protected:
+  void onEvalError(const std::string& message) const override
+  {
+    ++errorCount;
+    lastError = message;
+  }
+};
+
+} // namespace
+
+TEST(WidgetTextMath, TextIntParsesAPlainNumber)
+{
+  RecordingWidget w;
+  w.setText("42");
+  EXPECT_EQ(42, w.textInt());
+  EXPECT_EQ(0, w.errorCount);
+}
+
+TEST(WidgetTextMath, TextIntEvaluatesAnExpression)
+{
+  RecordingWidget w;
+  w.setText("3*4+5");
+  EXPECT_EQ(17, w.textInt());
+  EXPECT_EQ(0, w.errorCount);
+}
+
+TEST(WidgetTextMath, TextIntOnUnparseableTextReportsTheErrorAndReturnsOne)
+{
+  RecordingWidget w;
+  w.setText("not a number");
+  EXPECT_EQ(1, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+  EXPECT_FALSE(w.lastError.empty());
+}
+
+TEST(WidgetTextMath, TextIntClampsAResultOutsideIntRangeWithoutOverflow)
+{
+  RecordingWidget w;
+  w.setText("99999999999"); // ~1e11, past INT_MAX
+  EXPECT_EQ(INT_MAX, w.textInt());
+  EXPECT_EQ(0, w.errorCount);
+
+  w.setText("-99999999999");
+  EXPECT_EQ(INT_MIN, w.textInt());
+}
+
+TEST(WidgetTextMath, TextDoubleParsesAPlainNumber)
+{
+  RecordingWidget w;
+  w.setText("3.5");
+  EXPECT_DOUBLE_EQ(3.5, w.textDouble());
+  EXPECT_EQ(0, w.errorCount);
+}
+
+TEST(WidgetTextMath, TextDoubleRoundsToThreeDecimals)
+{
+  RecordingWidget w;
+  w.setText("1/3");
+  EXPECT_DOUBLE_EQ(0.333, w.textDouble());
+}
+
+TEST(WidgetTextMath, TextDoubleOnUnparseableTextReportsTheErrorAndReturnsOne)
+{
+  RecordingWidget w;
+  w.setText("???");
+  EXPECT_DOUBLE_EQ(1.0, w.textDouble());
+  EXPECT_EQ(1, w.errorCount);
+}


### PR DESCRIPTION
Closes #178.

## What

Unit test coverage for ui-layer widgets and message plumbing:

- **`ui::NumberEntry`**: `setValue()` clamps to `[min,max]`; on focus-leave `"2*8"` evaluates to 16, `"7/2"` rounds to 4, `"abc"` reverts to the last valid value, an evaluated result outside `INT_MIN`/`INT_MAX` saturates instead of overflowing, and `setMin()`/`setMax()` change the clamp range for values set afterwards.
- **`Widget::textInt()`/`textDouble()`** math expressions: plain numbers, expressions, `textDouble`'s rounding to 3 decimals, and the INT saturation on out-of-range results.
- **`ui::to_string(MessageType)`**: every enum value has a non-empty name; anything `>= kFirstRegisteredMessage` returns `""`.

## Refactor (required for the textInt/textDouble tests to run headless)

`Widget::textInt()`/`textDouble()` used to call `ui::Alert::show()` directly on a parse failure, which blocks on a live, message-pumping `ui::Manager` - unusable from a plain unit test. Factored the error path out into a new protected virtual `Widget::onEvalError(const std::string&) const`, whose default implementation is exactly the old `ui::Alert::show()` call. This is a pure seam: every existing caller of `textInt()`/`textDouble()` keeps its current behavior unchanged; tests subclass `Widget` and override `onEvalError()` to record the failure instead.

## Bug found and fixed (test infrastructure, not production code)

`test/app/crash/read_document_tests.cpp` (added in #177) called `base::remove_directory()` on its fixture directories without first clearing their contents. `base::remove_directory()` only removes an empty directory, and `crash::write_document()` always populates its target directory with several files - so the test only passed on a pristine checkout, and failed on any second run (the exact case that surfaced this while re-verifying it in this session). Added a small recursive-delete helper local to the test file and used it both before each fixture write and after each test, so re-running the suite is idempotent.

## Known omission

The frame limiter in `ui::Manager::flipDisplay()` (commit 60b4d2b4f, listed as a stretch goal in the issue) reads real wall-clock time via `base::current_tick()` and is driven by `Manager`'s actual `she::Display` flip cycle - there's no injectable clock seam, and building one cleanly is a real refactor of its own, not a small one like the `textInt`/`textDouble` seam above. Leaving this for a follow-up scoped around introducing that seam specifically.

## Testing

- Full local build (`ninja`) succeeds with no new warnings.
- Full `ctest` suite: 57/57 passing, no regressions.
- Verified the `read_document_tests` fix by running the binary twice in a row (previously failed on the second run with "Error removing directory"; now passes both times).

🤖 Generated with [Claude Code](https://claude.com/claude-code)