### PR TITLE
Cover skin fonts, UI scale guess, status bar parser, layer guards

### DIFF
--- a/src/app/commands/cmd_remove_layer.cpp
+++ b/src/app/commands/cmd_remove_layer.cpp
@@ -9,6 +9,8 @@
 #include "config.h"
 #endif
 
+#include "app/commands/cmd_remove_layer.h"
+
 #include "app/app.h"
 #include "app/commands/command.h"
 #include "app/context_access.h"
@@ -23,6 +25,25 @@
 #include "ui/widget.h"
 
 namespace app {
+
+bool wouldRemoveAllLayers(int layersInRange, int totalLayers)
+{
+  return layersInRange == totalLayers;
+}
+
+bool wouldRemoveTheLastLayer(int totalLayers)
+{
+  return totalLayers == 1;
+}
+
+bool anyLayerHidden(const std::vector<bool>& layerVisibility)
+{
+  for (bool visible : layerVisibility) {
+    if (!visible)
+      return true;
+  }
+  return false;
+}
 
 class RemoveLayerCommand : public Command {
 public:
@@ -60,19 +81,16 @@ void RemoveLayerCommand::onExecute(Context* context)
     // TODO the range of selected layer should be in doc::Site.
     auto range = App::instance()->timeline()->range();
     if (range.enabled()) {
-      if (range.layers() == sprite->countLayers()) {
+      if (wouldRemoveAllLayers(range.layers(), sprite->countLayers())) {
         ui::Alert::show("Error<<You cannot delete all layers.||&OK");
         return;
       }
 
-      bool anyHidden = false;
+      std::vector<bool> visibility;
       for (LayerIndex layer = range.layerEnd(); layer >= range.layerBegin(); --layer) {
-        if (!sprite->indexToLayer(layer)->isVisible()) {
-          anyHidden = true;
-          break;
-        }
+        visibility.push_back(sprite->indexToLayer(layer)->isVisible());
       }
-      if (anyHidden &&
+      if (anyLayerHidden(visibility) &&
           ui::Alert::show("Warning"
                            "<<One or more of the selected layers are hidden."
                            "<<Do you really want to delete them?"
@@ -87,7 +105,7 @@ void RemoveLayerCommand::onExecute(Context* context)
       transaction.commit();
     }
     else {
-      if (sprite->countLayers() == 1) {
+      if (wouldRemoveTheLastLayer(sprite->countLayers())) {
         ui::Alert::show("Error<<You cannot delete the last layer.||&OK");
         return;
       }

--- a/src/app/commands/cmd_remove_layer.h
+++ b/src/app/commands/cmd_remove_layer.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include <vector>
+
+namespace app {
+
+  // Pure guard checks used by RemoveLayerCommand::onExecute() before it
+  // shows any confirmation dialog. Exposed here (rather than kept
+  // file-local) so at least these decisions are directly testable - the
+  // ui::Alert::show() confirmations themselves still need a live,
+  // message-pumping ui::Manager and aren't yet injectable/mockable (see
+  // issue #180), so the full command flow, including what happens after a
+  // Yes/No choice, isn't reachable from a headless test.
+
+  // True if removing the selected range would leave the sprite with no
+  // layers at all.
+  bool wouldRemoveAllLayers(int layersInRange, int totalLayers);
+
+  // True if the sprite has only a single layer left to remove.
+  bool wouldRemoveTheLastLayer(int totalLayers);
+
+  // True if any of the given layers (by visibility, in any order) is
+  // hidden - used to decide whether to warn before deleting it/them.
+  bool anyLayerHidden(const std::vector<bool>& layerVisibility);
+
+} // namespace app

--- a/src/app/modules/gui.cpp
+++ b/src/app/modules/gui.cpp
@@ -156,6 +156,13 @@ static bool create_main_display(bool gpuAccel,
   return (main_display != nullptr);
 }
 
+int guessUiScale(int screenH, int fallbackH)
+{
+  if (screenH <= 0)
+    screenH = fallbackH;
+  return MID(1, 1 + (screenH >= 720) + (screenH >= 1200) + (screenH >= 1800), 4);
+}
+
 // Initializes GUI.
 int init_module_gui()
 {
@@ -196,18 +203,10 @@ int init_module_gui()
 	  #ifdef EMSCRIPTEN
 	  uiScale = 2;
 	  #else
-	  // Guess a sensible UI scale on the first run from the primary
-	  // display's resolution, keeping the post-scale (logical) screen
-	  // height usable for the editor (~400px is the practical minimum).
 	  // The initial window is only a small fallback size, so prefer the
 	  // real desktop height and only fall back to the window height when
-	  // it's unavailable. Note: on Hi-DPI setups SDL may report either
-	  // pixels or points depending on the platform, so the thresholds are
-	  // deliberately conservative.
-	  int screenH = she::instance()->desktopSize().h;
-	  if (screenH <= 0)
-	      screenH = ui::display_h();
-	  uiScale = MID(1, 1 + (screenH >= 720) + (screenH >= 1200) + (screenH >= 1800), 4);
+	  // it's unavailable.
+	  uiScale = guessUiScale(she::instance()->desktopSize().h, ui::display_h());
 	  #endif
           Preferences::instance().experimental.uiScale(uiScale);
       }

--- a/src/app/modules/gui.cpp
+++ b/src/app/modules/gui.cpp
@@ -1,6 +1,6 @@
-// Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C) 2021       LibreSprite contributors
-// Besprited   | Copyright (C) 2026       Veritaware
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// LibreSprite | Copyright (C) 2021      LibreSprite contributors
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/modules/gui.h
+++ b/src/app/modules/gui.h
@@ -1,5 +1,6 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C)      2024  LibreSprite contributors
+// Besprited   | Copyright (C)      2026  Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -32,6 +33,15 @@ namespace app {
 
   int init_module_gui();
   void exit_module_gui();
+
+  // First-run UI-scale guess: picks a scale from the primary display's
+  // resolution, keeping the post-scale (logical) screen height usable for
+  // the editor (~400px is the practical minimum). `screenH` is the real
+  // desktop height when known; when it isn't (<= 0), `fallbackH` (the
+  // initial small window's height) is used instead. Thresholds are
+  // deliberately conservative since on Hi-DPI setups SDL may report either
+  // pixels or points depending on the platform.
+  int guessUiScale(int screenH, int fallbackH);
 
   void update_screen_for_document(const Document* document);
 

--- a/src/app/modules/gui.h
+++ b/src/app/modules/gui.h
@@ -1,6 +1,6 @@
-// Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C)      2024  LibreSprite contributors
-// Besprited   | Copyright (C)      2026  Veritaware
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// LibreSprite | Copyright (C) 2024      LibreSprite contributors
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/skin/skin_theme.cpp
+++ b/src/app/ui/skin/skin_theme.cpp
@@ -29,6 +29,7 @@
 #include "app/ui/skin/skin_slider_property.h"
 #include "app/ui/skin/skin_style_property.h"
 #include "app/ui/skin/skin_theme.h"
+#include "app/ui/skin/skin_theme_fonts.h"
 
 #include <ranges>
 
@@ -380,8 +381,8 @@ namespace app::skin
     // (default) entry, then any remaining entries so loadFont() still has
     // fallbacks to try if the preferred file can't be loaded.
     void collectFontFamily(const tinyxml2::XMLElement* family,
-                            const std::string& skinId,
                             const std::string& lang,
+                            const std::function<std::optional<std::string>(const std::string&)>& resolveFontFile,
                             std::vector<std::pair<std::string, size_t>>& output) {
       struct Entry {
         std::string name;
@@ -426,7 +427,7 @@ namespace app::skin
       auto addEntry = [&](const Entry* entry) {
         if (!entry)
           return;
-        if (auto path = findSkinFontFile(skinId, entry->name))
+        if (auto path = resolveFontFile(entry->name))
           output.emplace_back(*path, entry->size);
       };
 
@@ -438,6 +439,31 @@ namespace app::skin
     }
 
   } // anonymous namespace
+
+  void parseFontFamiliesFromSkinXml(
+    const tinyxml2::XMLDocument& doc,
+    const std::string& lang,
+    const std::function<std::optional<std::string>(const std::string&)>& resolveFontFile,
+    std::vector<std::pair<std::string, size_t>>& mainFonts,
+    std::vector<std::pair<std::string, size_t>>& miniFonts)
+  {
+    const tinyxml2::XMLElement* fonts = tinyxml2::XMLHandle(const_cast<tinyxml2::XMLDocument*>(&doc))
+                                        .FirstChildElement("skin")
+                                        .FirstChildElement("fonts").ToElement();
+    if (!fonts)
+      return;
+
+    for (const auto* family = fonts->FirstChildElement("family"); family;
+         family = family->NextSiblingElement("family")) {
+      const char* id = family->Attribute("id");
+      if (!id)
+        continue;
+      if (std::strcmp(id, "main_font") == 0)
+        collectFontFamily(family, lang, resolveFontFile, mainFonts);
+      else if (std::strcmp(id, "mini_font") == 0)
+        collectFontFamily(family, lang, resolveFontFile, miniFonts);
+    }
+  }
 
   void SkinTheme::loadFontFamiliesFromSkinXml(const std::string& skinId,
                                                std::vector<std::pair<std::string, size_t>>& mainFonts,
@@ -454,23 +480,10 @@ namespace app::skin
       return;
     }
 
-    const tinyxml2::XMLElement* fonts = tinyxml2::XMLHandle(doc.get())
-                                        .FirstChildElement("skin")
-                                        .FirstChildElement("fonts").ToElement();
-    if (!fonts)
-      return;
-
-    const std::string lang = getLanguage();
-    for (const auto* family = fonts->FirstChildElement("family"); family;
-         family = family->NextSiblingElement("family")) {
-      const char* id = family->Attribute("id");
-      if (!id)
-        continue;
-      if (std::strcmp(id, "main_font") == 0)
-        collectFontFamily(family, skinId, lang, mainFonts);
-      else if (std::strcmp(id, "mini_font") == 0)
-        collectFontFamily(family, skinId, lang, miniFonts);
-    }
+    parseFontFamiliesFromSkinXml(
+      *doc, getLanguage(),
+      [&skinId](const std::string& name) { return findSkinFontFile(skinId, name); },
+      mainFonts, miniFonts);
   }
 
   void SkinTheme::loadXml(const std::string& skinId)

--- a/src/app/ui/skin/skin_theme_fonts.h
+++ b/src/app/ui/skin/skin_theme_fonts.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include "tinyxml2.h"
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace app::skin {
+
+  // Parses the <skin><fonts> section of a skin.xml document into ordered
+  // (file, size) candidate lists for the main and mini font families -
+  // SkinTheme::loadFontFamiliesFromSkinXml()'s actual logic, pulled out so
+  // it's reachable with an in-memory tinyxml2::XMLDocument and a fake
+  // `resolveFontFile` instead of a real skins/fonts directory on disk.
+  //
+  // Within each <family>, the entry whose `lang` attribute list contains
+  // `lang` goes first, then the language-less (default) entry, then any
+  // remaining entries - same fallback order loadFont() then tries them in.
+  // A candidate is only appended to the output list if resolveFontFile()
+  // finds it (returns a path); candidates that don't resolve are dropped
+  // silently, same as findSkinFontFile() failing in the real code path.
+  void parseFontFamiliesFromSkinXml(
+    const tinyxml2::XMLDocument& doc,
+    const std::string& lang,
+    const std::function<std::optional<std::string>(const std::string& fontName)>& resolveFontFile,
+    std::vector<std::pair<std::string, size_t>>& mainFonts,
+    std::vector<std::pair<std::string, size_t>>& miniFonts);
+
+} // namespace app::skin

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -1,5 +1,5 @@
-// Aseprite    | Copyright (C) 2001-2016  David Capello
-// Besprited   | Copyright (C) 2026       Veritaware
+// Aseprite  | Copyright (C) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// Besprited   | Copyright (C) 2026       Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -30,6 +30,7 @@
 #include "app/ui/skin/skin_style_property.h"
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui/status_bar.h"
+#include "app/ui/status_bar_text.h"
 #include "app/ui/timeline.h"
 #include "app/ui/toolbar.h"
 #include "app/ui/zoom_entry.h"
@@ -265,6 +266,41 @@ private:
   std::vector<Indicator*>::iterator m_iterator;
 };
 
+std::vector<StatusBarTextToken> tokenizeStatusBarText(const std::string& text)
+{
+  std::vector<StatusBarTextToken> tokens;
+  const char* start = text.c_str();
+
+  for (auto i = start; *i; ) {
+    // Icon
+    if (*i == ':' && (i == start || *(i-1) == ' ')) {
+      const char* j = i+1;
+      for (; *j; ++j) {
+        if (*j == ':')
+          break;
+      }
+
+      if (*j && (*(j+1) == 0 || *(j+1) == ' ')) {
+        if (i != start) {
+          // Here i is ':' and i-1 is a whitespace ' '
+          tokens.push_back({StatusBarTextToken::Kind::Text, std::string(start, i-1)});
+        }
+
+        tokens.push_back({StatusBarTextToken::Kind::Icon, std::string(i+1, j)});
+
+        start = i = (*(j+1) == ' ' ? j+2 : j+1);
+        continue;
+      }
+    }
+    ++i;
+  }
+
+  if (*start != 0)
+    tokens.push_back({StatusBarTextToken::Kind::Text, std::string(start)});
+
+  return tokens;
+}
+
 class StatusBar::IndicatorsGeneration {
 public:
   IndicatorsGeneration(StatusBar::Indicators* indicators)
@@ -279,34 +315,16 @@ public:
   IndicatorsGeneration& add(const char* text) {
     auto theme = SkinTheme::instance();
 
-    for (auto i = text; *i; ) {
-      // Icon
-      if (*i == ':' && (i == text || *(i-1) == ' ')) {
-        const char* j = i+1;
-        for (; *j; ++j) {
-          if (*j == ':')
-            break;
-        }
-
-        if (*j && (*(j+1) == 0 || *(j+1) == ' ')) {
-          if (i != text) {
-            // Here i is ':' and i-1 is a whitespace ' '
-            m_indicators->addTextIndicator(std::string(text, i-1).c_str());
-          }
-
-          auto part = theme->getPartById("icon_" + std::string(i+1, j));
-          if (part)
-            add(part.get(), true);
-
-          text = i = (*(j+1) == ' ' ? j+2: j+1);
-	  continue;
-        }
+    for (auto& token : tokenizeStatusBarText(text)) {
+      if (token.kind == StatusBarTextToken::Kind::Text) {
+        m_indicators->addTextIndicator(token.value.c_str());
       }
-      ++i;
+      else {
+        auto part = theme->getPartById("icon_" + token.value);
+        if (part)
+          add(part.get(), true);
+      }
     }
-
-    if (*text != 0)
-      m_indicators->addTextIndicator(text);
 
     return *this;
   }

--- a/src/app/ui/status_bar_text.h
+++ b/src/app/ui/status_bar_text.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace app {
+
+  // A piece of StatusBar::IndicatorsGeneration::add()'s input text: either
+  // literal text to show as-is, or the name of an icon (SkinTheme part
+  // "icon_<name>") to show in its place.
+  struct StatusBarTextToken {
+    enum class Kind { Text, Icon };
+    Kind kind;
+    std::string value;
+  };
+
+  // Splits `text` on ":name:" icon markers - a ':' at the start of the
+  // string or right after a space, followed by a run of non-':' characters,
+  // followed by a ':' that is itself at the end of the string or right
+  // before a space - into a sequence of Text/Icon tokens. Anything that
+  // doesn't match that exact shape (a lone trailing ':', a ':' with no
+  // matching close, etc.) is left as literal text.
+  //
+  // Pulled out of IndicatorsGeneration::add() (which otherwise needs a live
+  // SkinTheme::instance() and Indicators widget to look up/show each icon)
+  // so the character-by-character scanning itself - the part regressed by
+  // commit cba84ff20 ("Fix freeze and out-of-bounds memory read with : in
+  // layer names") - is directly testable.
+  std::vector<StatusBarTextToken> tokenizeStatusBarText(const std::string& text);
+
+} // namespace app

--- a/test/app/gui_scale_tests.cpp
+++ b/test/app/gui_scale_tests.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/modules/gui.h"
+
+using namespace app;
+
+TEST(GuessUiScale, ThresholdsProduceTheExpectedScale)
+{
+  EXPECT_EQ(1, guessUiScale(719, 0)) << "just under the first threshold";
+  EXPECT_EQ(2, guessUiScale(720, 0));
+  EXPECT_EQ(2, guessUiScale(1199, 0));
+  EXPECT_EQ(3, guessUiScale(1200, 0));
+  EXPECT_EQ(3, guessUiScale(1799, 0));
+  EXPECT_EQ(4, guessUiScale(1800, 0));
+  EXPECT_EQ(4, guessUiScale(4320, 0)) << "well past the top threshold, still capped at 4";
+}
+
+TEST(GuessUiScale, AnUnknownScreenHeightFallsBackToTheGivenHeight)
+{
+  EXPECT_EQ(guessUiScale(1200, 0), guessUiScale(0, 1200));
+  EXPECT_EQ(guessUiScale(720, 0), guessUiScale(-1, 720));
+}
+
+TEST(GuessUiScale, MinimumScaleIsOne)
+{
+  EXPECT_EQ(1, guessUiScale(0, 0));
+  EXPECT_EQ(1, guessUiScale(1, 1));
+}

--- a/test/app/remove_layer_guards_tests.cpp
+++ b/test/app/remove_layer_guards_tests.cpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/commands/cmd_remove_layer.h"
+
+using namespace app;
+
+TEST(RemoveLayerGuards, WouldRemoveAllLayersOnlyWhenTheRangeCoversEveryLayer)
+{
+  EXPECT_TRUE(wouldRemoveAllLayers(3, 3));
+  EXPECT_FALSE(wouldRemoveAllLayers(2, 3));
+  EXPECT_FALSE(wouldRemoveAllLayers(0, 3));
+}
+
+TEST(RemoveLayerGuards, WouldRemoveTheLastLayerOnlyWhenExactlyOneLayerIsLeft)
+{
+  EXPECT_TRUE(wouldRemoveTheLastLayer(1));
+  EXPECT_FALSE(wouldRemoveTheLastLayer(2));
+  EXPECT_FALSE(wouldRemoveTheLastLayer(0)) << "0 layers isn't the 'last layer' case";
+}
+
+TEST(RemoveLayerGuards, AnyLayerHiddenIsFalseWhenEveryLayerIsVisible)
+{
+  EXPECT_FALSE(anyLayerHidden({true, true, true}));
+}
+
+TEST(RemoveLayerGuards, AnyLayerHiddenIsTrueWhenAtLeastOneLayerIsHidden)
+{
+  EXPECT_TRUE(anyLayerHidden({true, false, true}));
+  EXPECT_TRUE(anyLayerHidden({false}));
+}
+
+TEST(RemoveLayerGuards, AnyLayerHiddenIsFalseForAnEmptyList)
+{
+  EXPECT_FALSE(anyLayerHidden({}));
+}

--- a/test/app/skin_theme_fonts_tests.cpp
+++ b/test/app/skin_theme_fonts_tests.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/ui/skin/skin_theme_fonts.h"
+
+#include <algorithm>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace app::skin;
+
+namespace {
+
+// A resolver that "finds" every candidate name, mapping it to itself -
+// isolates the tests from the real skins/fonts directories on disk while
+// still letting fallback ordering (which candidate is tried first) show
+// through in the output.
+std::optional<std::string> resolveAll(const std::string& name)
+{
+  return name;
+}
+
+// A resolver that only "finds" names in the given allow-list - used to
+// exercise the "preferred candidate isn't available, fall back to the
+// next one" path.
+std::function<std::optional<std::string>(const std::string&)>
+resolveOnly(std::initializer_list<std::string> allowed)
+{
+  std::vector<std::string> list(allowed);
+  return [list](const std::string& name) -> std::optional<std::string> {
+    if (std::find(list.begin(), list.end(), name) != list.end())
+      return name;
+    return std::nullopt;
+  };
+}
+
+std::unique_ptr<tinyxml2::XMLDocument> parse(const std::string& xml)
+{
+  auto doc = std::make_unique<tinyxml2::XMLDocument>();
+  doc->Parse(xml.c_str());
+  return doc;
+}
+
+} // namespace
+
+TEST(SkinThemeFonts, MainAndMiniFamiliesAreKeyedByTheFamilyId)
+{
+  auto doc = parse(R"(
+    <skin>
+      <fonts>
+        <family id="main_font"><font name="main.ttf" size="8"/></family>
+        <family id="mini_font"><font name="mini.ttf" size="6"/></family>
+      </fonts>
+    </skin>
+  )");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "en", resolveAll, mainFonts, miniFonts);
+
+  ASSERT_EQ(1u, mainFonts.size());
+  EXPECT_EQ("main.ttf", mainFonts[0].first);
+  EXPECT_EQ(8u, mainFonts[0].second);
+
+  ASSERT_EQ(1u, miniFonts.size());
+  EXPECT_EQ("mini.ttf", miniFonts[0].first);
+  EXPECT_EQ(6u, miniFonts[0].second);
+}
+
+TEST(SkinThemeFonts, AFamilyIdOtherThanMainOrMiniIsIgnored)
+{
+  auto doc = parse(R"(
+    <skin>
+      <fonts>
+        <family id="something_else"><font name="x.ttf" size="8"/></family>
+      </fonts>
+    </skin>
+  )");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "en", resolveAll, mainFonts, miniFonts);
+
+  EXPECT_TRUE(mainFonts.empty());
+  EXPECT_TRUE(miniFonts.empty());
+}
+
+TEST(SkinThemeFonts, ALangMatchingEntryIsPreferredOverTheLanguagelessDefault)
+{
+  auto doc = parse(R"(
+    <skin>
+      <fonts>
+        <family id="main_font">
+          <font name="default.ttf" size="8"/>
+          <font name="japanese.ttf" size="8" lang="ja,jp"/>
+        </family>
+      </fonts>
+    </skin>
+  )");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "ja", resolveAll, mainFonts, miniFonts);
+
+  ASSERT_EQ(2u, mainFonts.size());
+  EXPECT_EQ("japanese.ttf", mainFonts[0].first) << "the lang match goes first";
+  EXPECT_EQ("default.ttf", mainFonts[1].first) << "then the language-less default, as a fallback";
+}
+
+TEST(SkinThemeFonts, WithNoLangMatchTheLanguagelessDefaultIsChosen)
+{
+  auto doc = parse(R"(
+    <skin>
+      <fonts>
+        <family id="main_font">
+          <font name="japanese.ttf" size="8" lang="ja,jp"/>
+          <font name="default.ttf" size="8"/>
+        </family>
+      </fonts>
+    </skin>
+  )");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "en", resolveAll, mainFonts, miniFonts);
+
+  ASSERT_EQ(2u, mainFonts.size());
+  EXPECT_EQ("default.ttf", mainFonts[0].first);
+  EXPECT_EQ("japanese.ttf", mainFonts[1].first) << "still offered as a fallback";
+}
+
+TEST(SkinThemeFonts, WhenThePreferredCandidateDoesNotResolveTheNextOneIsUsed)
+{
+  auto doc = parse(R"(
+    <skin>
+      <fonts>
+        <family id="main_font">
+          <font name="missing.ttf" size="8" lang="ja"/>
+          <font name="fallback.ttf" size="8"/>
+        </family>
+      </fonts>
+    </skin>
+  )");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "ja", resolveOnly({"fallback.ttf"}), mainFonts, miniFonts);
+
+  ASSERT_EQ(1u, mainFonts.size());
+  EXPECT_EQ("fallback.ttf", mainFonts[0].first)
+    << "the lang-matched candidate didn't resolve to a file, so it's dropped "
+       "and the next candidate in fallback order is used instead";
+}
+
+TEST(SkinThemeFonts, AMissingFontsElementProducesEmptyLists)
+{
+  auto doc = parse("<skin></skin>");
+
+  std::vector<std::pair<std::string, size_t>> mainFonts, miniFonts;
+  parseFontFamiliesFromSkinXml(*doc, "en", resolveAll, mainFonts, miniFonts);
+
+  EXPECT_TRUE(mainFonts.empty());
+  EXPECT_TRUE(miniFonts.empty());
+}

--- a/test/app/status_bar_text_tests.cpp
+++ b/test/app/status_bar_text_tests.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "tests.h"
+
+#include "app/ui/status_bar_text.h"
+
+using namespace app;
+using Kind = StatusBarTextToken::Kind;
+
+namespace {
+
+::testing::AssertionResult isText(const StatusBarTextToken& t, const std::string& value)
+{
+  if (t.kind != Kind::Text)
+    return ::testing::AssertionFailure() << "expected a Text token, got an Icon token (\"" << t.value << "\")";
+  if (t.value != value)
+    return ::testing::AssertionFailure() << "expected text \"" << value << "\", got \"" << t.value << "\"";
+  return ::testing::AssertionSuccess();
+}
+
+::testing::AssertionResult isIcon(const StatusBarTextToken& t, const std::string& value)
+{
+  if (t.kind != Kind::Icon)
+    return ::testing::AssertionFailure() << "expected an Icon token, got a Text token (\"" << t.value << "\")";
+  if (t.value != value)
+    return ::testing::AssertionFailure() << "expected icon \"" << value << "\", got \"" << t.value << "\"";
+  return ::testing::AssertionSuccess();
+}
+
+} // namespace
+
+// Regression coverage for commit cba84ff20 ("Fix freeze and out-of-bounds
+// memory read with : in layer names"): a lone ':' with no matching close
+// used to read `*(j+1)` one byte past the string's terminator once `j`
+// itself stopped on the terminator (an infinite loop/freeze scanning
+// forward, and an OOB read past it). These are exactly its repro cases.
+
+TEST(TokenizeStatusBarText, ATrailingColonWithNothingAfterItIsLiteralText)
+{
+  auto tokens = tokenizeStatusBarText("a:");
+  ASSERT_EQ(1u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "a:"));
+}
+
+TEST(TokenizeStatusBarText, ALeadingColonWithNoClosingColonIsLiteralText)
+{
+  auto tokens = tokenizeStatusBarText(":b");
+  ASSERT_EQ(1u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], ":b"));
+}
+
+TEST(TokenizeStatusBarText, ColonsSeparatedBySpacesWithNoNameBetweenThemAreLiteralText)
+{
+  auto tokens = tokenizeStatusBarText("a : b");
+  ASSERT_EQ(1u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "a : b"));
+}
+
+TEST(TokenizeStatusBarText, AColonMarkerClosedByEndOfStringIsRecognized)
+{
+  auto tokens = tokenizeStatusBarText("layer :name:");
+  // "layer " then ":name:" - the opening ':' is preceded by a space, and
+  // "name" is closed by a ':' right at the end of the string - a proper
+  // icon marker, contrasting with the truly-unterminated cases above.
+  ASSERT_EQ(2u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "layer"));
+  EXPECT_TRUE(isIcon(tokens[1], "name"));
+}
+
+TEST(TokenizeStatusBarText, PlainTextWithNoColonsIsOneTextToken)
+{
+  auto tokens = tokenizeStatusBarText("hello world");
+  ASSERT_EQ(1u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "hello world"));
+}
+
+TEST(TokenizeStatusBarText, EmptyStringProducesNoTokens)
+{
+  EXPECT_TRUE(tokenizeStatusBarText("").empty());
+}
+
+TEST(TokenizeStatusBarText, AnIconMarkerAtTheStartOfTheStringIsRecognized)
+{
+  auto tokens = tokenizeStatusBarText(":icon: rest");
+  ASSERT_EQ(2u, tokens.size());
+  EXPECT_TRUE(isIcon(tokens[0], "icon"));
+  EXPECT_TRUE(isText(tokens[1], "rest"));
+}
+
+TEST(TokenizeStatusBarText, AnIconMarkerInTheMiddleSplitsTheSurroundingText)
+{
+  auto tokens = tokenizeStatusBarText("before :icon: after");
+  ASSERT_EQ(3u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "before"));
+  EXPECT_TRUE(isIcon(tokens[1], "icon"));
+  EXPECT_TRUE(isText(tokens[2], "after"));
+}
+
+TEST(TokenizeStatusBarText, MultipleIconMarkersAreAllRecognized)
+{
+  auto tokens = tokenizeStatusBarText(":one: mid :two:");
+  ASSERT_EQ(3u, tokens.size());
+  EXPECT_TRUE(isIcon(tokens[0], "one"));
+  EXPECT_TRUE(isText(tokens[1], "mid"));
+  EXPECT_TRUE(isIcon(tokens[2], "two"));
+}
+
+TEST(TokenizeStatusBarText, AColonNotAtAWordBoundaryIsLiteralText)
+{
+  // The opening ':' must be at the very start or right after a space -
+  // "a:b:" has its ':' preceded by 'a', not a space, so it's never treated
+  // as an icon marker at all.
+  auto tokens = tokenizeStatusBarText("a:b:");
+  ASSERT_EQ(1u, tokens.size());
+  EXPECT_TRUE(isText(tokens[0], "a:b:"));
+}


### PR DESCRIPTION
Closes #180.

## What

Unit test coverage for the four "refactor-first" leftovers, each behind a small testability seam:

- **`SkinTheme::loadFontFamiliesFromSkinXml()`**: the `<family>`/`<font>` selection logic (main vs mini lists, a lang-matching entry preferred over the language-less default, remaining entries kept as fallbacks, an unresolvable candidate dropped in favor of the next one) is now a free `parseFontFamiliesFromSkinXml()` taking an in-memory `tinyxml2::XMLDocument` and a file-resolver callback, so tests don't need real skins/fonts directories on disk.
- **First-run UI-scale guess**: extracted to `guessUiScale(screenH, fallbackH)` in `app/modules/gui.h`/`.cpp`; table-tested at and around every threshold (≥720 → 2, ≥1200 → 3, ≥1800 → 4), the `<=0` → fallback path, and the floor of 1.
- **StatusBar's `":icon_name:"` indicator text parser**: extracted to `tokenizeStatusBarText()` in a new `status_bar_text.h`, independent of `SkinTheme::instance()`/the `Indicators` widget. Regression coverage for commit cba84ff20 ("Fix freeze and out-of-bounds memory read with `:` in layer names"): `"a:"`, `":b"`, `"a : b"`, and a colon not preceded by a string-start/space all stay as literal text instead of triggering the unterminated-marker scan that used to freeze/read out of bounds.
- **`RemoveLayerCommand`'s guards**: `wouldRemoveAllLayers()`, `wouldRemoveTheLastLayer()`, and `anyLayerHidden()` pulled out as pure functions in a new `cmd_remove_layer.h`, so the "refuse to delete" decisions are directly testable without a live `ui::Manager` to show the confirmation dialogs they gate.

## Known gap (as flagged in the issue itself)

The actual `ui::Alert::show()` confirmations in `RemoveLayerCommand` (and the full `onExecute()` flow, including what happens after a Yes/No choice) remain untested - that's blocked on making `ui::Alert` confirmations injectable/mockable, which is a bigger change than the guard-extraction seam this PR adds. Left as a follow-up, consistent with how the issue describes it.

The (stretch) frame-limiter item was already covered as a known omission in #178/#186 and isn't repeated here.

## Testing

- Full local build (`ninja`) succeeds with no new warnings.
- Full `ctest` suite: 65/65 passing, no regressions.
- Verified the `tokenizeStatusBarText()` regression test by temporarily reintroducing the pre-fix condition (dropping the `*j &&` guard) and confirming `ColonsSeparatedBySpacesWithNoNameBetweenThemAreLiteralText` fails, then restoring the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)