### PR TITLE
Restore last valid value on bad expression

### DIFF
--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -14,6 +14,7 @@
 #include "base/bind.h"
 #include "base/string.h"
 #include "clip/clip.h"
+#include "evalmath/evalmath.h"
 #include "she/font.h"
 #include "she/keys.h"
 #include "ui/manager.h"
@@ -205,6 +206,7 @@ bool Entry::onProcessMessage(Message* msg)
 
     case kFocusEnterMessage: {
       m_got_focus_message = true;
+      rememberTextForRestore();
       View* view = View::getView(this);
       gfx::Rect rect = view ? view->viewportBounds() : bounds();
       int scale = 2*guiscale();
@@ -231,6 +233,8 @@ bool Entry::onProcessMessage(Message* msg)
     }
 
     case kFocusLeaveMessage:
+      restoreLastEvalText();
+
       invalidate();
 
       m_timer.stop();
@@ -484,13 +488,40 @@ void Entry::onSetText()
 
 void Entry::onChange()
 {
-  // Live-change subscribers commonly read textInt()/textDouble() to update
-  // a preview; while the user is still typing (e.g. a lone "-" before a
-  // negative number, or a trailing operator) the expression is not yet
-  // valid, and we must not pop an error Alert on every keystroke. The
-  // error still surfaces when the value is read on commit.
-  Widget::ScopedEvalErrorSilence noAlertWhileTyping;
   Change();
+}
+
+void Entry::rememberTextForRestore()
+{
+  m_textOnFocusEnter = text();
+}
+
+void Entry::restoreLastEvalText()
+{
+  // Only fields something actually reads as a number (see
+  // Widget::isTextReadAsNumber()) are validated this way - a plain text
+  // entry is never touched, whatever it happens to contain.
+  if (!isTextReadAsNumber())
+    return;
+
+  // What's typed still evaluates, so it stands as the known-good text.
+  if (evalmath::eval(text()))
+    return;
+
+  // It doesn't: the user left behind something half-typed, like the lone
+  // "-" of a negative number. Fall back to the last text that evaluated,
+  // or - if nothing has yet, because editing went wrong on the very first
+  // keystroke - to whatever the field held when they started typing.
+  // By value: setText() below overwrites the member this would alias.
+  const std::string good =
+    hasLastEvalText() ? lastEvalText() : m_textOnFocusEnter;
+
+  if (good.empty() || good == text() || !evalmath::eval(good))
+    return;
+
+  // onSetText() clamps the caret into the new, shorter text for us.
+  setText(good);
+  onChange();
 }
 
 gfx::Rect Entry::onGetEntryTextBounds() const

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -1,6 +1,6 @@
-// Aseprite UI Library
-// Copyright (C) 2001-2016  David Capello
-// Besprited | Copyright (C) 2026 Veritaware
+// UI Library
+// Aseprite  | Copyright (C) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -1,5 +1,6 @@
 // Aseprite UI Library
 // Copyright (C) 2001-2016  David Capello
+// Besprited | Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -483,6 +484,12 @@ void Entry::onSetText()
 
 void Entry::onChange()
 {
+  // Live-change subscribers commonly read textInt()/textDouble() to update
+  // a preview; while the user is still typing (e.g. a lone "-" before a
+  // negative number, or a trailing operator) the expression is not yet
+  // valid, and we must not pop an error Alert on every keystroke. The
+  // error still surfaces when the value is read on commit.
+  Widget::ScopedEvalErrorSilence noAlertWhileTyping;
   Change();
 }
 

--- a/src/ui/entry.cpp
+++ b/src/ui/entry.cpp
@@ -46,6 +46,8 @@ Entry::Entry(std::size_t maxsize, const char* format, ...)
   , m_recent_focused(false)
   , m_lock_selection(false)
   , m_got_focus_message(false)
+  , m_validValue(0.0)
+  , m_hasValidText(false)
 {
   enableFlags(CTRL_RIGHT_CLICK);
 
@@ -206,7 +208,6 @@ bool Entry::onProcessMessage(Message* msg)
 
     case kFocusEnterMessage: {
       m_got_focus_message = true;
-      rememberTextForRestore();
       View* view = View::getView(this);
       gfx::Rect rect = view ? view->viewportBounds() : bounds();
       int scale = 2*guiscale();
@@ -233,7 +234,7 @@ bool Entry::onProcessMessage(Message* msg)
     }
 
     case kFocusLeaveMessage:
-      restoreLastEvalText();
+      restoreLastValidText();
 
       invalidate();
 
@@ -481,6 +482,17 @@ void Entry::onSetText()
 {
   Widget::onSetText();
 
+  // Remember this text if it evaluates, so restoreLastValidText() has
+  // something to go back to. This runs for every text change, so the value
+  // a window fills the field with when it is built counts too - waiting
+  // until something reads the entry as a number would miss it, and reading
+  // is up to the window.
+  if (auto val = evalmath::eval(text())) {
+    m_validText = text();
+    m_validValue = val.value();
+    m_hasValidText = true;
+  }
+
   int textlen = textLength();
   if (m_caret >= 0 && m_caret > textlen)
     m_caret = textlen;
@@ -491,36 +503,31 @@ void Entry::onChange()
   Change();
 }
 
-void Entry::rememberTextForRestore()
+double Entry::onEvalFallback() const
 {
-  m_textOnFocusEnter = text();
+  return m_hasValidText ? m_validValue : 0.0;
 }
 
-void Entry::restoreLastEvalText()
+void Entry::restoreLastValidText()
 {
   // Only fields something actually reads as a number (see
   // Widget::isTextReadAsNumber()) are validated this way - a plain text
   // entry is never touched, whatever it happens to contain.
-  if (!isTextReadAsNumber())
+  if (!isTextReadAsNumber() || !m_hasValidText)
     return;
 
-  // What's typed still evaluates, so it stands as the known-good text.
-  if (evalmath::eval(text()))
+  // What's in the field still evaluates, so there is nothing to put right.
+  if (text() == m_validText || evalmath::eval(text()))
     return;
 
   // It doesn't: the user left behind something half-typed, like the lone
-  // "-" of a negative number. Fall back to the last text that evaluated,
-  // or - if nothing has yet, because editing went wrong on the very first
-  // keystroke - to whatever the field held when they started typing.
-  // By value: setText() below overwrites the member this would alias.
-  const std::string good =
-    hasLastEvalText() ? lastEvalText() : m_textOnFocusEnter;
-
-  if (good.empty() || good == text() || !evalmath::eval(good))
-    return;
+  // "-" of a negative number. Put the last text that evaluated back, so
+  // the field can't be left showing something that counts as nothing.
+  // By value: setText() feeds onSetText(), which rewrites m_validText.
+  const std::string valid = m_validText;
 
   // onSetText() clamps the caret into the new, shorter text for us.
-  setText(good);
+  setText(valid);
   onChange();
 }
 

--- a/src/ui/entry.h
+++ b/src/ui/entry.h
@@ -1,6 +1,6 @@
-// Aseprite UI Library
-// Copyright (C) 2001-2013, 2015  David Capello
-// Besprited | Copyright (C) 2026 Veritaware
+// UI Library
+// Aseprite  | Copyright (C) 2001-2015 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/ui/entry.h
+++ b/src/ui/entry.h
@@ -1,5 +1,6 @@
 // Aseprite UI Library
 // Copyright (C) 2001-2013, 2015  David Capello
+// Besprited | Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -53,6 +54,14 @@ namespace ui {
     void onPaint(PaintEvent& ev) override;
     void onSetText() override;
 
+    // Snapshot the value the user is about to edit, as the last resort for
+    // restoreLastEvalText(). Called when this entry gains focus.
+    void rememberTextForRestore();
+
+    // If this entry is read as a math expression and what it currently
+    // holds no longer evaluates, put back the last text that did.
+    void restoreLastEvalText();
+
     // New Events
     virtual void onChange();
     virtual gfx::Rect onGetEntryTextBounds() const;
@@ -97,6 +106,10 @@ namespace ui {
     bool m_recent_focused;
     bool m_lock_selection;
     bool m_got_focus_message;
+
+    // text() as it was when this entry last gained focus, i.e. the value
+    // the user started editing from. Used by restoreLastEvalText().
+    std::string m_textOnFocusEnter;
     std::string m_suffix;
   };
 

--- a/src/ui/entry.h
+++ b/src/ui/entry.h
@@ -54,13 +54,11 @@ namespace ui {
     void onPaint(PaintEvent& ev) override;
     void onSetText() override;
 
-    // Snapshot the value the user is about to edit, as the last resort for
-    // restoreLastEvalText(). Called when this entry gains focus.
-    void rememberTextForRestore();
-
     // If this entry is read as a math expression and what it currently
     // holds no longer evaluates, put back the last text that did.
-    void restoreLastEvalText();
+    void restoreLastValidText();
+
+    double onEvalFallback() const override;
 
     // New Events
     virtual void onChange();
@@ -107,9 +105,14 @@ namespace ui {
     bool m_lock_selection;
     bool m_got_focus_message;
 
-    // text() as it was when this entry last gained focus, i.e. the value
-    // the user started editing from. Used by restoreLastEvalText().
-    std::string m_textOnFocusEnter;
+    // The last text this entry held that evaluated as a math expression,
+    // and what it evaluated to. Tracked on every text change - including
+    // the one that fills the field when its window is built - so it does
+    // not depend on when, or whether, anything reads the entry.
+    std::string m_validText;
+    double m_validValue;
+    bool m_hasValidText;
+
     std::string m_suffix;
   };
 

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -21,7 +21,6 @@
 #include "she/font.h"
 #include "she/surface.h"
 #include "she/system.h"
-#include "ui/alert.h"
 #include "ui/init_theme_event.h"
 #include "ui/intern.h"
 #include "ui/layout_io.h"
@@ -39,8 +38,10 @@
 #include "ui/window.h"
 #include "evalmath/evalmath.h"
 
+#include <algorithm>
 #include <cctype>
 #include <climits>
+#include <cmath>
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
@@ -144,53 +145,53 @@ void Widget::initTheme()
   onInitTheme(ev);
 }
 
-void Widget::onEvalError(const std::string& message) const
+void Widget::onEvalError(const std::string& /*message*/) const
 {
-  ui::Alert::show("Error evaluating expression  <<%s||&OK", message.c_str());
+  // Nothing by default. This used to raise a modal ui::Alert, but
+  // textInt()/textDouble() are getters that dialogs poll on every
+  // keystroke to refresh a preview, and again after their window has
+  // closed to read the final values - so a half-typed expression popped an
+  // alert mid-word, and a bad one popped it once the field could no longer
+  // be corrected. Entry reverts to the last value that parsed instead.
 }
 
-namespace {
-  thread_local int g_evalErrorSilenceDepth = 0;
-}
-
-Widget::ScopedEvalErrorSilence::ScopedEvalErrorSilence()
+// Evaluates m_text, caching the result as the fallback for whatever is
+// typed next. Returns the last value that parsed (0 if none ever did) when
+// m_text doesn't parse, so a half-typed expression can never inject an
+// arbitrary number into whatever the caller drives.
+double Widget::evalText() const
 {
-  ++g_evalErrorSilenceDepth;
-}
+  m_textReadAsNumber = true;
 
-Widget::ScopedEvalErrorSilence::~ScopedEvalErrorSilence()
-{
-  --g_evalErrorSilenceDepth;
-}
+  auto val = evalmath::eval(m_text);
+  if (!val) {
+    onEvalError(val.error());
+    return m_lastEvalValue;
+  }
 
-bool Widget::isEvalErrorSilenced()
-{
-  return g_evalErrorSilenceDepth > 0;
+  // evalmath doesn't reject division by zero, so an expression can parse
+  // and still come back as inf/NaN. Those aren't usable results either.
+  if (!std::isfinite(val.value())) {
+    onEvalError("result is not a finite number");
+    return m_lastEvalValue;
+  }
+
+  m_lastEvalText = m_text;
+  m_lastEvalValue = val.value();
+  m_hasLastEval = true;
+  return val.value();
 }
 
 int Widget::textInt() const
 {
-  auto val = evalmath::eval(m_text);
-  if(!val)
-  {
-    if (!isEvalErrorSilenced())
-      onEvalError(val.error());
-    return 1;
-  }
-
-  return static_cast<int>(std::clamp<long>(val.value(), INT_MIN, INT_MAX));
+  // Clamped as a double: converting an out-of-range double straight to an
+  // integer type is undefined behaviour.
+  return static_cast<int>(std::clamp<double>(evalText(), INT_MIN, INT_MAX));
 }
 
 double Widget::textDouble() const
 {
-  auto val = evalmath::eval(m_text);
-  if(!val)
-  {
-    if (!isEvalErrorSilenced())
-      onEvalError(val.error());
-    return 1.0;
-  }
-  return std::round(val.value() * 1000.0) / 1000.0;
+  return std::round(evalText() * 1000.0) / 1000.0;
 }
 
 int Widget::textLength() const

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -155,10 +155,9 @@ void Widget::onEvalError(const std::string& /*message*/) const
   // be corrected. Entry reverts to the last value that parsed instead.
 }
 
-// Evaluates m_text, caching the result as the fallback for whatever is
-// typed next. Returns the last value that parsed (0 if none ever did) when
-// m_text doesn't parse, so a half-typed expression can never inject an
-// arbitrary number into whatever the caller drives.
+// Evaluates m_text, falling back to onEvalFallback() when it doesn't
+// parse, so a half-typed expression can never inject an arbitrary number
+// into whatever the caller drives.
 double Widget::evalText() const
 {
   m_textReadAsNumber = true;
@@ -166,19 +165,16 @@ double Widget::evalText() const
   auto val = evalmath::eval(m_text);
   if (!val) {
     onEvalError(val.error());
-    return m_lastEvalValue;
+    return onEvalFallback();
   }
 
-  // evalmath doesn't reject division by zero, so an expression can parse
-  // and still come back as inf/NaN. Those aren't usable results either.
+  // evalmath doesn't reject every division by zero, so an expression can
+  // parse and still come back as inf/NaN. Those aren't usable either.
   if (!std::isfinite(val.value())) {
     onEvalError("result is not a finite number");
-    return m_lastEvalValue;
+    return onEvalFallback();
   }
 
-  m_lastEvalText = m_text;
-  m_lastEvalValue = val.value();
-  m_hasLastEval = true;
   return val.value();
 }
 

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -149,12 +149,32 @@ void Widget::onEvalError(const std::string& message) const
   ui::Alert::show("Error evaluating expression  <<%s||&OK", message.c_str());
 }
 
+namespace {
+  thread_local int g_evalErrorSilenceDepth = 0;
+}
+
+Widget::ScopedEvalErrorSilence::ScopedEvalErrorSilence()
+{
+  ++g_evalErrorSilenceDepth;
+}
+
+Widget::ScopedEvalErrorSilence::~ScopedEvalErrorSilence()
+{
+  --g_evalErrorSilenceDepth;
+}
+
+bool Widget::isEvalErrorSilenced()
+{
+  return g_evalErrorSilenceDepth > 0;
+}
+
 int Widget::textInt() const
 {
   auto val = evalmath::eval(m_text);
   if(!val)
   {
-    onEvalError(val.error());
+    if (!isEvalErrorSilenced())
+      onEvalError(val.error());
     return 1;
   }
 
@@ -166,7 +186,8 @@ double Widget::textDouble() const
   auto val = evalmath::eval(m_text);
   if(!val)
   {
-    onEvalError(val.error());
+    if (!isEvalErrorSilenced())
+      onEvalError(val.error());
     return 1.0;
   }
   return std::round(val.value() * 1000.0) / 1000.0;

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -101,6 +101,22 @@ namespace ui {
     double textDouble() const;
     int textLength() const;
 
+    // While an instance of this lives on the stack, a failed
+    // textInt()/textDouble() evaluation is swallowed silently instead of
+    // being reported through onEvalError(). Used to avoid popping an error
+    // Alert on every keystroke of a live-updating entry (e.g. a dialog
+    // preview) while the user is still in the middle of typing an
+    // expression - the error still surfaces when the value is read on
+    // commit, outside of any live-change notification.
+    class ScopedEvalErrorSilence {
+    public:
+      ScopedEvalErrorSilence();
+      ~ScopedEvalErrorSilence();
+      ScopedEvalErrorSilence(const ScopedEvalErrorSilence&) = delete;
+      ScopedEvalErrorSilence& operator=(const ScopedEvalErrorSilence&) = delete;
+    };
+    static bool isEvalErrorSilenced();
+
     void setI18N();
     void setI18N(std::string_view i18n);
     void setText(const std::string& text);

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -112,11 +112,6 @@ namespace ui {
     // all, i.e. some code does read it as a number rather than as text.
     bool isTextReadAsNumber() const { return m_textReadAsNumber; }
 
-    // True once one of those calls actually evaluated something;
-    // lastEvalText() is the text() that produced the last usable value.
-    bool hasLastEvalText() const { return m_hasLastEval; }
-    const std::string& lastEvalText() const { return m_lastEvalText; }
-
     void setI18N();
     void setI18N(std::string_view i18n);
     void setText(const std::string& text);
@@ -412,11 +407,16 @@ namespace ui {
     virtual void onSetBgColor();
 
     // Called by textInt()/textDouble() when text() can't be parsed as a
-    // math expression. Notification only - the caller falls back to
-    // lastEvalText()'s value regardless, so this must not block or show
-    // modal UI: it runs on every keystroke of a live-updating entry, and
-    // may run long after the window owning the widget has been closed.
+    // math expression. Notification only - the caller uses
+    // onEvalFallback() regardless, so this must not block or show modal
+    // UI: it runs on every keystroke of a live-updating entry, and may run
+    // long after the window owning the widget has been closed.
     virtual void onEvalError(const std::string& message) const;
+
+    // The value textInt()/textDouble() return when text() doesn't
+    // evaluate. Plain widgets have nothing better to offer than zero;
+    // Entry keeps the last value it held that did evaluate.
+    virtual double onEvalFallback() const { return 0.0; }
 
   private:
     // Shared back end of textInt()/textDouble().
@@ -433,12 +433,8 @@ namespace ui {
     std::string m_text;          // Widget text
     std::string m_i18n;          // Text before translation
 
-    // Last text()/value pair that textInt()/textDouble() managed to
-    // evaluate, used as their fallback when the current text doesn't
-    // parse. Mutable because both are const getters.
-    mutable std::string m_lastEvalText;
-    mutable double m_lastEvalValue = 0.0;
-    mutable bool m_hasLastEval = false;
+    // Set by textInt()/textDouble(), so a widget can tell whether anything
+    // reads it as a number. Mutable because both are const getters.
     mutable bool m_textReadAsNumber = false;
     mutable std::shared_ptr<she::Font> m_font;   // Cached font returned by the theme
     gfx::Color m_bgColor;        // Background color

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -97,25 +97,25 @@ namespace ui {
     bool hasText() const { return hasFlags(HAS_TEXT); }
 
     const std::string& text() const { return m_text; }
+
+    // Evaluate text() as a math expression. These are plain getters that
+    // callers poll freely - including on every keystroke, to drive a live
+    // preview - so they never report a parse failure to the user and never
+    // invent a value for one: text that doesn't evaluate yields the last
+    // value that did (see hasLastEvalText()), or 0 if there isn't one.
     int textInt() const;
     double textDouble() const;
+
     int textLength() const;
 
-    // While an instance of this lives on the stack, a failed
-    // textInt()/textDouble() evaluation is swallowed silently instead of
-    // being reported through onEvalError(). Used to avoid popping an error
-    // Alert on every keystroke of a live-updating entry (e.g. a dialog
-    // preview) while the user is still in the middle of typing an
-    // expression - the error still surfaces when the value is read on
-    // commit, outside of any live-change notification.
-    class ScopedEvalErrorSilence {
-    public:
-      ScopedEvalErrorSilence();
-      ~ScopedEvalErrorSilence();
-      ScopedEvalErrorSilence(const ScopedEvalErrorSilence&) = delete;
-      ScopedEvalErrorSilence& operator=(const ScopedEvalErrorSilence&) = delete;
-    };
-    static bool isEvalErrorSilenced();
+    // True once textInt()/textDouble() has been called on this widget at
+    // all, i.e. some code does read it as a number rather than as text.
+    bool isTextReadAsNumber() const { return m_textReadAsNumber; }
+
+    // True once one of those calls actually evaluated something;
+    // lastEvalText() is the text() that produced the last usable value.
+    bool hasLastEvalText() const { return m_hasLastEval; }
+    const std::string& lastEvalText() const { return m_lastEvalText; }
 
     void setI18N();
     void setI18N(std::string_view i18n);
@@ -412,12 +412,16 @@ namespace ui {
     virtual void onSetBgColor();
 
     // Called by textInt()/textDouble() when text() can't be parsed as a
-    // math expression. Default implementation blocks on a ui::Alert, which
-    // requires a live, message-pumping ui::Manager - override this (e.g. in
-    // a headless test) to observe/record the error without it.
+    // math expression. Notification only - the caller falls back to
+    // lastEvalText()'s value regardless, so this must not block or show
+    // modal UI: it runs on every keystroke of a live-updating entry, and
+    // may run long after the window owning the widget has been closed.
     virtual void onEvalError(const std::string& message) const;
 
   private:
+    // Shared back end of textInt()/textDouble().
+    double evalText() const;
+
     void removeChild(WidgetsList::iterator& it);
     void paint(Graphics* graphics, const gfx::Region& drawRegion);
     bool paintEvent(Graphics* graphics);
@@ -428,6 +432,14 @@ namespace ui {
     Theme* m_theme;              // Widget's theme
     std::string m_text;          // Widget text
     std::string m_i18n;          // Text before translation
+
+    // Last text()/value pair that textInt()/textDouble() managed to
+    // evaluate, used as their fallback when the current text doesn't
+    // parse. Mutable because both are const getters.
+    mutable std::string m_lastEvalText;
+    mutable double m_lastEvalValue = 0.0;
+    mutable bool m_hasLastEval = false;
+    mutable bool m_textReadAsNumber = false;
     mutable std::shared_ptr<she::Font> m_font;   // Cached font returned by the theme
     gfx::Color m_bgColor;        // Background color
     gfx::Rect m_bounds;

--- a/test/ui/entry_expr_tests.cpp
+++ b/test/ui/entry_expr_tests.cpp
@@ -1,0 +1,193 @@
+// Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#define TEST_GUI
+#include "tests.h"
+
+#include "ui/entry.h"
+#include "ui/message.h"
+
+#include <string>
+
+using namespace ui;
+
+namespace {
+
+// Entry validates an expression on kFocusLeaveMessage - send one directly
+// instead of standing up a Manager to move focus around for real.
+void loseFocus(Entry& entry)
+{
+  Message msg(kFocusLeaveMessage);
+  entry.sendMessage(&msg);
+}
+
+// Focus-enter can't be sent the same way: handling it also starts a blink
+// timer, talks to she and re-selects the text through the theme's font,
+// none of which exists in a headless test. The part that matters here is
+// the snapshot Entry takes of the value the user is about to edit.
+class TestEntry : public Entry {
+public:
+  using Entry::Entry;
+  void gainFocus() { rememberTextForRestore(); }
+};
+
+// Stands in for a dialog that reads an entry as a number on every edit to
+// refresh a live preview (Canvas Size, Sprite Size, Import Sprite Sheet...).
+class PreviewReader {
+public:
+  explicit PreviewReader(Entry& entry) : m_entry(entry)
+  {
+    m_entry.Change.connect([this]{ read(); });
+  }
+
+  void read() { value = m_entry.textInt(); ++reads; }
+
+  int value = 0;
+  int reads = 0;
+
+private:
+  Entry& m_entry;
+};
+
+} // namespace
+
+TEST(EntryExpr, HalfTypedExpressionDoesNotMoveThePreviewValue)
+{
+  Entry entry(32, "300");
+  PreviewReader preview(entry);
+  preview.read();
+  EXPECT_EQ(300, preview.value);
+
+  // Typing the "-" of a negative number leaves the entry holding something
+  // that doesn't evaluate; the preview must sit still rather than jump to
+  // an invented number.
+  entry.setText("-");
+  preview.read();
+  EXPECT_EQ(300, preview.value);
+
+  entry.setText("-25");
+  preview.read();
+  EXPECT_EQ(-25, preview.value);
+}
+
+TEST(EntryExpr, FocusLeaveRestoresTheLastTextThatEvaluated)
+{
+  Entry entry(32, "0");
+  PreviewReader preview(entry);
+  preview.read(); // the dialog reads it as a number => it's a numeric field
+
+  entry.setText("-");
+  preview.read();
+
+  loseFocus(entry);
+  EXPECT_EQ("0", entry.text());
+}
+
+TEST(EntryExpr, FocusLeaveKeepsTextThatStillEvaluates)
+{
+  Entry entry(32, "0");
+  PreviewReader preview(entry);
+  preview.read();
+
+  entry.setText("16*2");
+  preview.read();
+  EXPECT_EQ(32, preview.value);
+
+  loseFocus(entry);
+  EXPECT_EQ("16*2", entry.text()); // the expression itself is preserved
+}
+
+TEST(EntryExpr, FocusLeaveNotifiesListenersAfterRestoringTheText)
+{
+  Entry entry(32, "10");
+  PreviewReader preview(entry);
+  preview.read();
+
+  entry.setText("10+"); // trailing operator
+  int readsBeforeFocusLeave = preview.reads;
+
+  loseFocus(entry);
+  EXPECT_EQ("10", entry.text());
+  EXPECT_GT(preview.reads, readsBeforeFocusLeave);
+  EXPECT_EQ(10, preview.value);
+}
+
+// The revert only applies to entries something reads as a number. A plain
+// text entry must keep whatever the user typed, even if it happens to look
+// like a broken expression.
+TEST(EntryExpr, PlainTextEntryIsLeftAloneOnFocusLeave)
+{
+  Entry entry(32, "");
+
+  entry.setText("Layer-");
+  loseFocus(entry);
+  EXPECT_EQ("Layer-", entry.text());
+
+  entry.setText("-");
+  loseFocus(entry);
+  EXPECT_EQ("-", entry.text());
+}
+
+// Even a numeric-looking text entry stays untouched as long as nothing
+// evaluates it - a layer named "123" is still just a name.
+TEST(EntryExpr, NumericLookingTextEntryIsLeftAloneOnFocusLeave)
+{
+  Entry entry(32, "123");
+
+  entry.setText("abc");
+  loseFocus(entry);
+  EXPECT_EQ("abc", entry.text());
+}
+
+// The case from the Canvas Size dialog: the field opens on a valid value
+// that the dialog hasn't read yet, and the very first keystroke makes it
+// unparseable - so there is no previously evaluated text to go back to.
+// What the field held when editing started stands in for it.
+TEST(EntryExpr, FocusLeaveFallsBackToTheTextEditingStartedFrom)
+{
+  TestEntry entry(32, "0");
+  PreviewReader preview(entry);
+
+  entry.gainFocus();
+
+  entry.setText("-"); // first keystroke, before anything evaluated
+  preview.read();
+  EXPECT_EQ(0, preview.value); // no invented number reaches the preview
+
+  loseFocus(entry);
+  EXPECT_EQ("0", entry.text());
+}
+
+// A later good value wins over the one editing started from.
+TEST(EntryExpr, FocusLeavePrefersTheLastTextThatEvaluated)
+{
+  TestEntry entry(32, "5");
+  PreviewReader preview(entry);
+
+  entry.gainFocus();
+
+  entry.setText("7");
+  preview.read();
+  EXPECT_EQ(7, preview.value);
+
+  entry.setText("7+"); // trailing operator
+  preview.read();
+
+  loseFocus(entry);
+  EXPECT_EQ("7", entry.text());
+}
+
+// Focus alone must not turn a text field into a numeric one.
+TEST(EntryExpr, FocusEnterDoesNotMakeAPlainTextEntryNumeric)
+{
+  TestEntry entry(32, "123");
+
+  entry.gainFocus();
+  entry.setText("abc");
+  loseFocus(entry);
+
+  EXPECT_EQ("abc", entry.text());
+}

--- a/test/ui/entry_expr_tests.cpp
+++ b/test/ui/entry_expr_tests.cpp
@@ -16,26 +16,16 @@ using namespace ui;
 
 namespace {
 
-// Entry validates an expression on kFocusLeaveMessage - send one directly
-// instead of standing up a Manager to move focus around for real.
+// Entry puts a half-typed expression right on kFocusLeaveMessage - send
+// one directly instead of standing up a Manager to move focus for real.
 void loseFocus(Entry& entry)
 {
   Message msg(kFocusLeaveMessage);
   entry.sendMessage(&msg);
 }
 
-// Focus-enter can't be sent the same way: handling it also starts a blink
-// timer, talks to she and re-selects the text through the theme's font,
-// none of which exists in a headless test. The part that matters here is
-// the snapshot Entry takes of the value the user is about to edit.
-class TestEntry : public Entry {
-public:
-  using Entry::Entry;
-  void gainFocus() { rememberTextForRestore(); }
-};
-
-// Stands in for a dialog that reads an entry as a number on every edit to
-// refresh a live preview (Canvas Size, Sprite Size, Import Sprite Sheet...).
+// Stands in for a window that reads an entry as a number to refresh a live
+// preview (Canvas Size, Sprite Size, Import Sprite Sheet...).
 class PreviewReader {
 public:
   explicit PreviewReader(Entry& entry) : m_entry(entry)
@@ -73,17 +63,37 @@ TEST(EntryExpr, HalfTypedExpressionDoesNotMoveThePreviewValue)
   EXPECT_EQ(-25, preview.value);
 }
 
+// The case from the Canvas Size dialog. That window fills its border
+// fields with 0 when it is built but doesn't read them until something
+// changes, so the value to go back to has to come from the text itself,
+// not from a read.
+TEST(EntryExpr, FocusLeaveRestoresAValueNothingHadReadYet)
+{
+  Entry entry(32, "0"); // as the window fills it
+  PreviewReader preview(entry);
+
+  entry.setText("-");
+  preview.read(); // first read of all: the field is only now known numeric
+  EXPECT_EQ(0, preview.value);
+
+  loseFocus(entry);
+  EXPECT_EQ("0", entry.text());
+}
+
 TEST(EntryExpr, FocusLeaveRestoresTheLastTextThatEvaluated)
 {
   Entry entry(32, "0");
   PreviewReader preview(entry);
-  preview.read(); // the dialog reads it as a number => it's a numeric field
+  preview.read();
 
-  entry.setText("-");
+  entry.setText("-25");
+  preview.read();
+
+  entry.setText("-25*"); // trailing operator
   preview.read();
 
   loseFocus(entry);
-  EXPECT_EQ("0", entry.text());
+  EXPECT_EQ("-25", entry.text()); // not "0": the newer valid text wins
 }
 
 TEST(EntryExpr, FocusLeaveKeepsTextThatStillEvaluates)
@@ -106,16 +116,46 @@ TEST(EntryExpr, FocusLeaveNotifiesListenersAfterRestoringTheText)
   PreviewReader preview(entry);
   preview.read();
 
-  entry.setText("10+"); // trailing operator
-  int readsBeforeFocusLeave = preview.reads;
+  entry.setText("10+");
+  const int readsBefore = preview.reads;
 
   loseFocus(entry);
   EXPECT_EQ("10", entry.text());
-  EXPECT_GT(preview.reads, readsBeforeFocusLeave);
+  EXPECT_GT(preview.reads, readsBefore);
   EXPECT_EQ(10, preview.value);
 }
 
-// The revert only applies to entries something reads as a number. A plain
+// Repeated focus changes must not wear the restore value down - this is
+// what made the behaviour look random when it was snapshotted on
+// focus-enter instead of tracked on the text.
+TEST(EntryExpr, RepeatedFocusChangesKeepRestoringTheSameValue)
+{
+  Entry entry(32, "0");
+  PreviewReader preview(entry);
+  preview.read();
+
+  for (int i = 0; i < 5; ++i) {
+    entry.setText("-");
+    preview.read();
+    loseFocus(entry);
+    EXPECT_EQ("0", entry.text()) << "iteration " << i;
+  }
+}
+
+// A focus-leave with nothing wrong in the field must not disturb it.
+TEST(EntryExpr, FocusLeaveOnValidTextIsANoOp)
+{
+  Entry entry(32, "5");
+  PreviewReader preview(entry);
+  preview.read();
+
+  const int readsBefore = preview.reads;
+  loseFocus(entry);
+  EXPECT_EQ("5", entry.text());
+  EXPECT_EQ(readsBefore, preview.reads); // no spurious Change
+}
+
+// The restore only applies to entries something reads as a number. A plain
 // text entry must keep whatever the user typed, even if it happens to look
 // like a broken expression.
 TEST(EntryExpr, PlainTextEntryIsLeftAloneOnFocusLeave)
@@ -142,52 +182,18 @@ TEST(EntryExpr, NumericLookingTextEntryIsLeftAloneOnFocusLeave)
   EXPECT_EQ("abc", entry.text());
 }
 
-// The case from the Canvas Size dialog: the field opens on a valid value
-// that the dialog hasn't read yet, and the very first keystroke makes it
-// unparseable - so there is no previously evaluated text to go back to.
-// What the field held when editing started stands in for it.
-TEST(EntryExpr, FocusLeaveFallsBackToTheTextEditingStartedFrom)
+// An entry that has never held anything valid has nothing to restore, and
+// must not blank itself out trying.
+TEST(EntryExpr, EntryWithNoValidTextIsLeftAloneOnFocusLeave)
 {
-  TestEntry entry(32, "0");
+  Entry entry(32, "abc");
   PreviewReader preview(entry);
-
-  entry.gainFocus();
-
-  entry.setText("-"); // first keystroke, before anything evaluated
   preview.read();
-  EXPECT_EQ(0, preview.value); // no invented number reaches the preview
+  EXPECT_EQ(0, preview.value);
 
-  loseFocus(entry);
-  EXPECT_EQ("0", entry.text());
-}
-
-// A later good value wins over the one editing started from.
-TEST(EntryExpr, FocusLeavePrefersTheLastTextThatEvaluated)
-{
-  TestEntry entry(32, "5");
-  PreviewReader preview(entry);
-
-  entry.gainFocus();
-
-  entry.setText("7");
-  preview.read();
-  EXPECT_EQ(7, preview.value);
-
-  entry.setText("7+"); // trailing operator
+  entry.setText("def");
   preview.read();
 
   loseFocus(entry);
-  EXPECT_EQ("7", entry.text());
-}
-
-// Focus alone must not turn a text field into a numeric one.
-TEST(EntryExpr, FocusEnterDoesNotMakeAPlainTextEntryNumeric)
-{
-  TestEntry entry(32, "123");
-
-  entry.gainFocus();
-  entry.setText("abc");
-  loseFocus(entry);
-
-  EXPECT_EQ("abc", entry.text());
+  EXPECT_EQ("def", entry.text());
 }

--- a/test/ui/widget_text_math_tests.cpp
+++ b/test/ui/widget_text_math_tests.cpp
@@ -32,6 +32,16 @@ protected:
   }
 };
 
+// A widget that has something better to fall back on than zero, the way
+// ui::Entry does with the last text it held that evaluated.
+class FallbackWidget : public RecordingWidget {
+public:
+  double fallback = 0.0;
+
+protected:
+  double onEvalFallback() const override { return fallback; }
+};
+
 } // namespace
 
 TEST(WidgetTextMath, TextIntParsesAPlainNumber)
@@ -61,6 +71,19 @@ TEST(WidgetTextMath, TextIntClampsAResultOutsideIntRangeWithoutOverflow)
   EXPECT_EQ(INT_MIN, w.textInt());
 }
 
+// Clamping has to happen in double space; converting an out-of-range
+// double straight to an integer type is undefined behaviour.
+TEST(WidgetTextMath, HugeResultClampsWithoutUndefinedConversion)
+{
+  RecordingWidget w;
+  w.setText("9999999999*9999999999"); // ~1e20, past LONG_MAX
+  EXPECT_EQ(INT_MAX, w.textInt());
+  EXPECT_EQ(0, w.errorCount);
+
+  w.setText("-9999999999*9999999999");
+  EXPECT_EQ(INT_MIN, w.textInt());
+}
+
 TEST(WidgetTextMath, TextDoubleParsesAPlainNumber)
 {
   RecordingWidget w;
@@ -76,10 +99,9 @@ TEST(WidgetTextMath, TextDoubleRoundsToThreeDecimals)
   EXPECT_DOUBLE_EQ(0.333, w.textDouble());
 }
 
-// A widget nothing has ever evaluated successfully has no value to fall
-// back on, so unparseable text reads as 0 rather than as some invented
-// number.
-TEST(WidgetTextMath, UnparseableTextWithNoPriorValueReadsAsZero)
+// Text that doesn't evaluate never invents a number: a plain widget has
+// nothing to fall back on, so it reads as zero.
+TEST(WidgetTextMath, UnparseableTextReadsAsTheFallbackValue)
 {
   RecordingWidget w;
   w.setText("not a number");
@@ -90,77 +112,53 @@ TEST(WidgetTextMath, UnparseableTextWithNoPriorValueReadsAsZero)
   EXPECT_DOUBLE_EQ(0.0, w.textDouble());
 }
 
-// The half-typed states an expression passes through while it is being
-// edited must not move the value a live preview is reading.
-TEST(WidgetTextMath, HalfTypedExpressionKeepsTheLastValueThatParsed)
+TEST(WidgetTextMath, UnparseableTextUsesTheWidgetsOwnFallback)
 {
-  RecordingWidget w;
-
-  w.setText("300");
-  EXPECT_EQ(300, w.textInt());
+  FallbackWidget w;
+  w.fallback = 300.0;
 
   w.setText("-"); // start of a negative number
   EXPECT_EQ(300, w.textInt());
-  EXPECT_EQ(1, w.errorCount);
+  EXPECT_DOUBLE_EQ(300.0, w.textDouble());
+  EXPECT_EQ(2, w.errorCount);
 
-  w.setText("-1"); // ...finished
-  EXPECT_EQ(-1, w.textInt());
-  EXPECT_EQ(1, w.errorCount);
-
-  w.setText("-1*"); // trailing operator
-  EXPECT_EQ(-1, w.textInt());
+  w.setText("-25"); // ...finished
+  EXPECT_EQ(-25, w.textInt());
+  EXPECT_EQ(2, w.errorCount);
 }
 
-TEST(WidgetTextMath, LastEvalTextTracksTheTextThatParsed)
-{
-  RecordingWidget w;
-  EXPECT_FALSE(w.hasLastEvalText());
-
-  w.setText("16*2");
-  EXPECT_EQ(32, w.textInt());
-  EXPECT_TRUE(w.hasLastEvalText());
-  EXPECT_EQ("16*2", w.lastEvalText());
-
-  // A failed evaluation leaves the known-good text alone.
-  w.setText("16*");
-  EXPECT_EQ(32, w.textInt());
-  EXPECT_EQ("16*2", w.lastEvalText());
-}
-
-// hasLastEvalText() is what tells an Entry it is a numeric field at all, so
-// it must stay false for text nothing reads as a number.
-TEST(WidgetTextMath, HasLastEvalTextStaysFalseUntilTextIsReadAsANumber)
-{
-  RecordingWidget w;
-  w.setText("123");
-  EXPECT_FALSE(w.hasLastEvalText());
-  EXPECT_EQ(123, w.textInt());
-  EXPECT_TRUE(w.hasLastEvalText());
-}
-
-// evalmath happily divides by zero, so a parseable expression can still
-// produce inf/NaN - neither is a usable value to hand a caller.
+// A result that parses but isn't a usable number falls back too. evalmath
+// rejects most division by zero itself, so this guards the rest.
 TEST(WidgetTextMath, NonFiniteResultIsTreatedAsAFailedEvaluation)
 {
-  RecordingWidget w;
-  w.setText("10");
-  EXPECT_EQ(10, w.textInt());
+  FallbackWidget w;
+  w.fallback = 10.0;
 
   w.setText("1/0");
   EXPECT_EQ(10, w.textInt());
   EXPECT_EQ(1, w.errorCount);
-  EXPECT_EQ("10", w.lastEvalText());
+
+  w.setText("0/0");
+  EXPECT_EQ(10, w.textInt());
 }
 
-// Clamping has to happen in double space; converting an out-of-range
-// double straight to an integer type is undefined behaviour.
-TEST(WidgetTextMath, HugeResultClampsWithoutUndefinedConversion)
+// isTextReadAsNumber() is what tells an Entry it is a numeric field at
+// all, so it must stay false for text nothing reads as a number.
+TEST(WidgetTextMath, IsTextReadAsNumberStaysFalseUntilTextIsReadAsANumber)
 {
   RecordingWidget w;
-  w.setText("9999999999*9999999999"); // ~1e20, past LONG_MAX
-  EXPECT_EQ(INT_MAX, w.textInt());
-  EXPECT_EQ(0, w.errorCount);
+  w.setText("123");
+  EXPECT_FALSE(w.isTextReadAsNumber());
+  EXPECT_EQ(123, w.textInt());
+  EXPECT_TRUE(w.isTextReadAsNumber());
+}
 
-  w.setText("-9999999999*9999999999");
-  EXPECT_EQ(INT_MIN, w.textInt());
+// It is set even when the read fails - the read is what makes the widget
+// numeric, not whether that particular text happened to parse.
+TEST(WidgetTextMath, IsTextReadAsNumberIsSetEvenWhenTheTextDoesNotParse)
+{
+  RecordingWidget w;
+  w.setText("-");
+  EXPECT_EQ(0, w.textInt());
+  EXPECT_TRUE(w.isTextReadAsNumber());
 }

--- a/test/ui/widget_text_math_tests.cpp
+++ b/test/ui/widget_text_math_tests.cpp
@@ -93,3 +93,39 @@ TEST(WidgetTextMath, TextDoubleOnUnparseableTextReportsTheErrorAndReturnsOne)
   EXPECT_DOUBLE_EQ(1.0, w.textDouble());
   EXPECT_EQ(1, w.errorCount);
 }
+
+TEST(WidgetTextMath, ScopedEvalErrorSilenceSwallowsTheErrorButKeepsTheFallback)
+{
+  RecordingWidget w;
+  w.setText("-"); // a half-typed negative number
+
+  {
+    Widget::ScopedEvalErrorSilence silence;
+    EXPECT_EQ(1, w.textInt());
+    EXPECT_DOUBLE_EQ(1.0, w.textDouble());
+    EXPECT_EQ(0, w.errorCount);
+  }
+
+  // Once the guard is gone the error surfaces again (e.g. on commit).
+  EXPECT_EQ(1, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+}
+
+TEST(WidgetTextMath, ScopedEvalErrorSilenceNestsAndRestores)
+{
+  RecordingWidget w;
+  w.setText("not a number");
+
+  {
+    Widget::ScopedEvalErrorSilence outer;
+    {
+      Widget::ScopedEvalErrorSilence inner;
+      EXPECT_TRUE(Widget::isEvalErrorSilenced());
+      w.textInt();
+    }
+    EXPECT_TRUE(Widget::isEvalErrorSilenced());
+    w.textInt();
+  }
+  EXPECT_FALSE(Widget::isEvalErrorSilenced());
+  EXPECT_EQ(0, w.errorCount);
+}

--- a/test/ui/widget_text_math_tests.cpp
+++ b/test/ui/widget_text_math_tests.cpp
@@ -17,9 +17,8 @@ using namespace ui;
 namespace {
 
 // Widget::textInt()/textDouble() report a parse failure through the
-// overridable onEvalError() hook - the default implementation blocks on a
-// ui::Alert, which needs a live, message-pumping ui::Manager, so tests
-// override it instead to record the failure headlessly.
+// overridable onEvalError() hook - the default implementation does nothing,
+// so tests override it to observe that the failure was detected at all.
 class RecordingWidget : public Widget {
 public:
   mutable int errorCount = 0;
@@ -51,15 +50,6 @@ TEST(WidgetTextMath, TextIntEvaluatesAnExpression)
   EXPECT_EQ(0, w.errorCount);
 }
 
-TEST(WidgetTextMath, TextIntOnUnparseableTextReportsTheErrorAndReturnsOne)
-{
-  RecordingWidget w;
-  w.setText("not a number");
-  EXPECT_EQ(1, w.textInt());
-  EXPECT_EQ(1, w.errorCount);
-  EXPECT_FALSE(w.lastError.empty());
-}
-
 TEST(WidgetTextMath, TextIntClampsAResultOutsideIntRangeWithoutOverflow)
 {
   RecordingWidget w;
@@ -86,46 +76,91 @@ TEST(WidgetTextMath, TextDoubleRoundsToThreeDecimals)
   EXPECT_DOUBLE_EQ(0.333, w.textDouble());
 }
 
-TEST(WidgetTextMath, TextDoubleOnUnparseableTextReportsTheErrorAndReturnsOne)
-{
-  RecordingWidget w;
-  w.setText("???");
-  EXPECT_DOUBLE_EQ(1.0, w.textDouble());
-  EXPECT_EQ(1, w.errorCount);
-}
-
-TEST(WidgetTextMath, ScopedEvalErrorSilenceSwallowsTheErrorButKeepsTheFallback)
-{
-  RecordingWidget w;
-  w.setText("-"); // a half-typed negative number
-
-  {
-    Widget::ScopedEvalErrorSilence silence;
-    EXPECT_EQ(1, w.textInt());
-    EXPECT_DOUBLE_EQ(1.0, w.textDouble());
-    EXPECT_EQ(0, w.errorCount);
-  }
-
-  // Once the guard is gone the error surfaces again (e.g. on commit).
-  EXPECT_EQ(1, w.textInt());
-  EXPECT_EQ(1, w.errorCount);
-}
-
-TEST(WidgetTextMath, ScopedEvalErrorSilenceNestsAndRestores)
+// A widget nothing has ever evaluated successfully has no value to fall
+// back on, so unparseable text reads as 0 rather than as some invented
+// number.
+TEST(WidgetTextMath, UnparseableTextWithNoPriorValueReadsAsZero)
 {
   RecordingWidget w;
   w.setText("not a number");
+  EXPECT_EQ(0, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+  EXPECT_FALSE(w.lastError.empty());
 
-  {
-    Widget::ScopedEvalErrorSilence outer;
-    {
-      Widget::ScopedEvalErrorSilence inner;
-      EXPECT_TRUE(Widget::isEvalErrorSilenced());
-      w.textInt();
-    }
-    EXPECT_TRUE(Widget::isEvalErrorSilenced());
-    w.textInt();
-  }
-  EXPECT_FALSE(Widget::isEvalErrorSilenced());
+  EXPECT_DOUBLE_EQ(0.0, w.textDouble());
+}
+
+// The half-typed states an expression passes through while it is being
+// edited must not move the value a live preview is reading.
+TEST(WidgetTextMath, HalfTypedExpressionKeepsTheLastValueThatParsed)
+{
+  RecordingWidget w;
+
+  w.setText("300");
+  EXPECT_EQ(300, w.textInt());
+
+  w.setText("-"); // start of a negative number
+  EXPECT_EQ(300, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+
+  w.setText("-1"); // ...finished
+  EXPECT_EQ(-1, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+
+  w.setText("-1*"); // trailing operator
+  EXPECT_EQ(-1, w.textInt());
+}
+
+TEST(WidgetTextMath, LastEvalTextTracksTheTextThatParsed)
+{
+  RecordingWidget w;
+  EXPECT_FALSE(w.hasLastEvalText());
+
+  w.setText("16*2");
+  EXPECT_EQ(32, w.textInt());
+  EXPECT_TRUE(w.hasLastEvalText());
+  EXPECT_EQ("16*2", w.lastEvalText());
+
+  // A failed evaluation leaves the known-good text alone.
+  w.setText("16*");
+  EXPECT_EQ(32, w.textInt());
+  EXPECT_EQ("16*2", w.lastEvalText());
+}
+
+// hasLastEvalText() is what tells an Entry it is a numeric field at all, so
+// it must stay false for text nothing reads as a number.
+TEST(WidgetTextMath, HasLastEvalTextStaysFalseUntilTextIsReadAsANumber)
+{
+  RecordingWidget w;
+  w.setText("123");
+  EXPECT_FALSE(w.hasLastEvalText());
+  EXPECT_EQ(123, w.textInt());
+  EXPECT_TRUE(w.hasLastEvalText());
+}
+
+// evalmath happily divides by zero, so a parseable expression can still
+// produce inf/NaN - neither is a usable value to hand a caller.
+TEST(WidgetTextMath, NonFiniteResultIsTreatedAsAFailedEvaluation)
+{
+  RecordingWidget w;
+  w.setText("10");
+  EXPECT_EQ(10, w.textInt());
+
+  w.setText("1/0");
+  EXPECT_EQ(10, w.textInt());
+  EXPECT_EQ(1, w.errorCount);
+  EXPECT_EQ("10", w.lastEvalText());
+}
+
+// Clamping has to happen in double space; converting an out-of-range
+// double straight to an integer type is undefined behaviour.
+TEST(WidgetTextMath, HugeResultClampsWithoutUndefinedConversion)
+{
+  RecordingWidget w;
+  w.setText("9999999999*9999999999"); // ~1e20, past LONG_MAX
+  EXPECT_EQ(INT_MAX, w.textInt());
   EXPECT_EQ(0, w.errorCount);
+
+  w.setText("-9999999999*9999999999");
+  EXPECT_EQ(INT_MIN, w.textInt());
 }


### PR DESCRIPTION
Fixes #199

## Problem

`Widget::textInt()` / `textDouble()` evaluate `text()` as a math expression. When it didn't parse they did two things wrong:

1. **Invented a value** — they returned `1`. Dialogs read these on every keystroke to refresh a live preview, so half-typing `-25` into Canvas Size's *Left* left the field holding `-`, which counted as `1` and moved the *Width* preview from `300px` to `301px`.
2. **Raised a modal Alert** — from a getter. Dialogs also call it *after* their window has closed to read the final values, so the "Error evaluating expression" alert appeared once the field could no longer be corrected.

## Fix

`Entry` keeps the last text it held that evaluated, and puts it back when the field loses focus holding something that doesn't. `textInt()`/`textDouble()` return that text's value instead of inventing one, and the Alert is gone — reverting the field is the feedback, the same way `ui::NumberEntry` already works (#75), now for every entry read as a number.

The tracking happens in `Entry::onSetText()`, on the text itself. That matters: it covers **every** change, including the one that fills the field when its window is built, and it never depends on focus or on whether anything has read the entry yet. Two earlier attempts in this branch tied it to those things and were inconsistent as a result — Canvas Size never reads its border fields when it opens (`ButtonSet::setSelectedItem()` doesn't fire `ItemChange`, so `onDirChange()` never runs), and a focus-enter snapshot was re-taken by anything that bounced focus, including a tooltip.

Only entries something actually reads as a number are touched (`Widget::isTextReadAsNumber()`), so a plain text entry keeps whatever was typed — a layer named `123` is still just a name.

This works for the entries built in C++ too (colour sliders, despeckle) and for the `textDouble()` percentage fields, with no widget-type changes and no changes to the dialogs.

Two smaller correctness fixes in the same code:

- A non-finite result is treated as a failed evaluation, rather than being passed on as `inf`/`NaN`.
- Clamping happens in double space. Converting an out-of-range double straight to an integer type is undefined behaviour, which `9999999999*9999999999` reached.

## Tests

New `test/ui/entry_expr_tests.cpp` (10 tests) drives the real `Entry` focus-leave path, including the two cases that were broken: restoring a value nothing had read yet, and repeated focus changes restoring the same value every time. `widget_text_math_tests.cpp` covers the fallback hook, the non-finite guard and the out-of-range clamp. Full suite: 66/66 pass.

## Known boundary

A field its dialog only reads when you press OK (Palette Size, Goto Frame) is never marked numeric while you are editing, so it isn't restored on focus-leave. Its *value* is still safe — unparseable text reads as the last valid value rather than `1` — but the field can be left showing the bad text. Making those consistent means marking them numeric declaratively, i.e. moving them to `<numberentry>`; worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SNfy3JQpYaKt1SQJTSecc